### PR TITLE
Pedersen commitments + MiMC sponge

### DIFF
--- a/sbmtjs/package.json
+++ b/sbmtjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkp-sbmtjs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Storage-backed Merkle tree",
   "main": "index.js",
   "scripts": {

--- a/semaphorejs/package.json
+++ b/semaphorejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkp-semaphorejs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Zero-knowledge signaling on Ethereum",
   "main": "index.js",
   "scripts": {

--- a/semaphorejs/snark/semaphore-base.circom
+++ b/semaphorejs/snark/semaphore-base.circom
@@ -1,3 +1,4 @@
+include "../node_modules/circomlib/circuits/pedersen.circom";
 include "../node_modules/circomlib/circuits/mimcsponge.circom";
 include "../node_modules/circomlib/circuits/bitify.circom";
 include "../node_modules/circomlib/circuits/eddsamimcsponge.circom";
@@ -82,11 +83,11 @@ template Semaphore(jubjub_field_size, n_levels, n_rounds) {
     component identity_pk_0_bits = Num2Bits(256);
     identity_pk_0_bits.in <== dbl3.xout;
 
-    component identity_commitment = Blake2s(2*256, 0);
+    component identity_commitment = Pedersen(2*256);
     // BEGIN identity commitment
     for (var i = 0; i < 256; i++) {
-      identity_commitment.in_bits[i] <== identity_pk_0_bits.out[i];
-      identity_commitment.in_bits[i + 256] <== identity_nullifier_bits.out[i];
+      identity_commitment.in[i] <== identity_pk_0_bits.out[i];
+      identity_commitment.in[i + 256] <== identity_nullifier_bits.out[i];
     }
     // END identity commitment
 
@@ -105,12 +106,7 @@ template Semaphore(jubjub_field_size, n_levels, n_rounds) {
       selectors[i].right ==> hashers[i].right;
     }
 
-    component identity_commitment_num = Bits2Num(253);
-    for (var i = 0; i < 253; i++) {
-      identity_commitment_num.in[i] <== identity_commitment.out[i];
-    }
-
-    identity_commitment_num.out ==> selectors[0].input_elem;
+    identity_commitment.out[0] ==> selectors[0].input_elem;
 
     for (var i = 1; i < n_levels; i++) {
       hashers[i-1].hash ==> selectors[i].input_elem;

--- a/semaphorejs/src/client/semaphore.js
+++ b/semaphorejs/src/client/semaphore.js
@@ -50,6 +50,13 @@ function hex(byteArray) {
   }).join('');
 }
 
+function pedersen_hash(ints) {
+  const p = babyJub.unpackPoint(pedersenHash.hash(Buffer.concat(
+             ints.map(x => x.leInt2Buff(32))
+  )));
+  return bigInt(p[0]);
+}
+
 const cutDownBits = function(b, bits) {
   let mask = bigInt(1);
   mask = mask.shl(bits).sub(bigInt(1));
@@ -89,11 +96,7 @@ class SemaphoreClient {
 
         this.identity_nullifier = loaded_identity.identity_nullifier;
 
-        const identity_commitment_ints = [bigInt(circomlib.babyJub.mulPointEscalar(pubKey, 8)[0]), bigInt(this.identity_nullifier)];
-        const identity_commitment_buffer = Buffer.concat(
-           identity_commitment_ints.map(x => x.leInt2Buff(32))
-        );
-        this.identity_commitment_buffer = identity_commitment_buffer;
+        this.identity_commitment = pedersen_hash([bigInt(pubKey[0]), bigInt(pubKey[1]), bigInt(this.identity_nullifier), bigInt(this.identity_r)]);
 
         this.web3 = new Web3(node_url);
         this.web3.eth.transactionConfirmationBlocks = transaction_confirmation_blocks;
@@ -115,11 +118,6 @@ class SemaphoreClient {
     async broadcast_signal(signal_str) {
         logger.info(`broadcasting signal ${signal_str}`);
 
-        const identity_commitment_digest = blake2.blake2sHex(this.identity_commitment_buffer);
-        logger.verbose(`identity_commitment digest: ${identity_commitment_digest}`);
-        const identity_commitment_uncut = beBuff2int(new Buffer(identity_commitment_digest, 'hex'));
-        logger.verbose(`identity_commitment_uncut: ${identity_commitment_uncut}`);
-        this.identity_commitment = cutDownBits(identity_commitment_uncut, 253);
         logger.verbose(`identity_commitment: ${this.identity_commitment}`);
         //const prvKey = Buffer.from('0001020304050607080900010203040506070809000102030405060708090001', 'hex');
         const prvKey = Buffer.from(this.private_key, 'hex');
@@ -283,11 +281,7 @@ function generate_identity(logger) {
     const identity_nullifier = '0x' + crypto.randomBytes(31).toString('hex');
     logger.info(`generate identity from (private_key, public_key[0], public_key[1], identity_nullifier): (${private_key}, ${pubKey[0]}, ${pubKey[1]}, ${identity_nullifier})`);
 
-    const identity_commitment_ints = [bigInt(circomlib.babyJub.mulPointEscalar(pubKey, 8)[0]), bigInt(identity_nullifier)];
-    const identity_commitment_buffer = Buffer.concat(
-       identity_commitment_ints.map(x => x.leInt2Buff(32))
-    );
-    const identity_commitment = cutDownBits(beBuff2int(new Buffer(blake2.blake2sHex(identity_commitment_buffer), 'hex')), 253);
+		const identity_commitment = pedersen_hash([bigInt(pubKey[0]), bigInt(pubKey[1]), bigInt(this.identity_nullifier), bigInt(this.identity_r)]);
 
     logger.info(`identity_commitment : ${identity_commitment}`);
     const generated_identity = {

--- a/semaphorejs/src/web/template.html
+++ b/semaphorejs/src/web/template.html
@@ -106,7 +106,7 @@
         external_nullifier: 'auto',
         semaphore_server_url: 'https://semaphore-server.kobi.one',
         semaphore_server_address: '0x1929c15f4e818abf2549510622a50c440c474223',
-        semaphore_contract_address: '0x7A1f706D1051b320E876088cB38E28001f3E6130',
+        semaphore_contract_address: '0xcA23c213500773498f3083b3C78bcE289E6628A3',
         from_private_key: '0x6738837df169e8d6ffc6e33a2947e58096d644fa4aa6d74358c8d9d57c12cd21',
         from_address: '0x1929c15f4e818abf2549510622a50c440c474223',
         chain_id: '4',

--- a/semaphorejs/truffle-config.js
+++ b/semaphorejs/truffle-config.js
@@ -85,6 +85,7 @@ module.exports = {
       provider: () => {
 				return new HDWalletProvider(privateKey, "https://rinkeby.infura.io/v3/f4a3ad81db3f4750bd201955c8d20066");
 			},
+      gas: 7000000,
       network_id: 4,
       skipDryRun: true
     },


### PR DESCRIPTION
1. pedersen commitments are used for the identity commitment, saving a bunch of constraints
2. the MiMC sponge variant now uses a 0 constant and doesn't swap for the last round. there was a mistake where it did those things, as in other rounds. it seems that it doesn't matter much for security, but I prefer to match the paper