### PR TITLE
Fixes the permissioning test due to a typo in run_ganache.sh

### DIFF
--- a/semaphorejs/scripts/run_ganache.sh
+++ b/semaphorejs/scripts/run_ganache.sh
@@ -17,5 +17,5 @@
 # You should have received a copy of the GNU General Public License
 # along with semaphorejs.  If not, see <http://www.gnu.org/licenses/>.
 #
-../node_modules/.bin/ganache-cli -p 7545 -l 8800000 -i 5777 --account='0x6738837df169e8d6ffc6e33a2947e58096d644fa4aa6d74358c8d9d57c12cd21,100000000000000000000000000' --account='0x6738837df169e8d6ffc6e33a2947e58096d644fa4aa6d74358c8d9d57c12cd21,10000000000000000000000000' -b 1 -q
+../node_modules/.bin/ganache-cli -p 7545 -l 8800000 -i 5777 --account='0x6738837df169e8d6ffc6e33a2947e58096d644fa4aa6d74358c8d9d57c12cd21,100000000000000000000000000' --account='0x6738837df169e8d6ffc6e33a2947e58096d644fa4aa6d74358c8d9d57c12cd22,10000000000000000000000000' -b 1 -q
 


### PR DESCRIPTION
There was a typo in `run_ganache.sh` which only set up one account for `ganache-cli`. This caused the permissioning test in `semaphore.js` to fail as it uses `accounts[1]`. This PR fixes that typo.