### PR TITLE
Preparation for an audit

### DIFF
--- a/semaphorejs/package.json
+++ b/semaphorejs/package.json
@@ -42,7 +42,7 @@
     "truffle-privatekey-provider": "^1.1.0",
     "web3": "^1.0.0-beta.51",
     "webpack": "^4.30.0",
-    "websnark": "git+https://github.com/iden3/websnark.git",
+    "websnark": "git+https://github.com/iden3/websnark.git#3b6cf0c77e48ab0867a2d710c0b35794b16bde7d",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/semaphorejs/scripts/run_ganache.sh
+++ b/semaphorejs/scripts/run_ganache.sh
@@ -17,5 +17,5 @@
 # You should have received a copy of the GNU General Public License
 # along with semaphorejs.  If not, see <http://www.gnu.org/licenses/>.
 #
-../node_modules/.bin/ganache-cli -p 7545 -l 8800000 -i 5777 --account='0x6738837df169e8d6ffc6e33a2947e58096d644fa4aa6d74358c8d9d57c12cd21,100000000000000000000000000' --account='0x6738837df169e8d6ffc6e33a2947e58096d644fa4aa6d74358c8d9d57c12cd21,10000000000000000000000000' -b 1 -q
+../node_modules/.bin/ganache-cli -p 7545 -l 8800000 -i 5777 --account='0x6738837df169e8d6ffc6e33a2947e58096d644fa4aa6d74358c8d9d57c12cd21,100000000000000000000000000' --account='0x6738837df169e8d6ffc6e33a2947e58096d644fa4aa6d74358c8d9d57c12cd22,10000000000000000000000000' -b 1 -q
 

--- a/semaphorejs/test/contracts/semaphore.js
+++ b/semaphorejs/test/contracts/semaphore.js
@@ -200,6 +200,7 @@ contract('Semaphore', function (accounts) {
         let failed = false;
         let reason = '';
 
+        // Test if the transaction correctly reverts if the root is not in the root history
         try {
           await semaphore.broadcastSignal(
               signal_to_contract,
@@ -215,6 +216,8 @@ contract('Semaphore', function (accounts) {
         assert.equal(failed, true);
         assert.equal(reason, 'Semaphore: root not seen');
 
+        // Test for the alisasing bug in
+        // https://github.com/kobigurk/semaphore/issues/16
         failed = false;
         try {
           await semaphore.broadcastSignal(


### PR DESCRIPTION
This PR mainly adds documentation comments to the code.

It also changes `Semaphore.roots()` to `root`, which is a more accurate name.

It also fixes some bugs:

- `run_ganache.sh` where a typo caused only one account to be available. 
- the websnark dependency in `package.json`