### PR TITLE
Support for multiple external nullifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Semaphore is comprised of a zkSNARK statement, a few smart contracts, a server a
 Implemented in [**semaphorejs/contracts**](semaphorejs/contracts).
 
 #### Semaphore
-  The Semaphore contract is the base layer of Semaphore. Other contracts can build upon this to create applications that rely on anonymous signaling. Semaphore has a tree of allowed identities, a tree of signals, a set of previously broadcast nullifiers hashes, an external nullifier and a gas price refund price:
+  The Semaphore contract is the base layer of Semaphore. Other contracts can build upon this to create applications that rely on anonymous signaling. Semaphore has a tree of allowed identities, a tree of signals, a set of previously broadcast nullifiers hashes, multiple external nullifiers and a gas price refund price:
 
   * The tree of allowed identities allows a prover to show that they are an identity which is approved to signal.
   * The tree of signals allows a user to verify the integrity of a list of signals.
-  * The nullifiers hashes set and external nullifier allows the contract to prevent double signals by the same user, without exposing the specific user.
+  * The nullifiers hashes set and external nullifier allows the contract to prevent double signals by the same user, within the context of each external nullifier, without exposing the specific user.
   * The gas price refund price is a mechanism that supports transaction abstraction - a server can broadcast on behalf of a user to provide further anonymity, and in return they receive a refund and a small reward, with a maximum gas price for their transaction.
 
 The contract allows administrative operations that only the owner is allowed to perform:
 
   * Managing identities using the **insertIdentity** and **updateIdentity** methods.
-  * Setting the **external_nullifier**.
+  * Adding or removing an **external_nullifier**.
   * Setting the broadcast permissioning - whether only the owner can broadcast.
 
 The contract allows anyone to read the current state:

--- a/semaphorejs/contracts/Semaphore.sol
+++ b/semaphorejs/contracts/Semaphore.sol
@@ -26,8 +26,12 @@ import "./Ownable.sol";
 
 contract Semaphore is Verifier, MultipleMerkleTree, Ownable {
     // The external_nullifier helps to prevent double-signalling by the same
-    // user.
-    uint256 public external_nullifier;
+    // user. The external_nullifiers mapping allows for quick lookups of the
+    // existence of an external nullifier, and the external_nullifiers_by_index
+    // allows for easy enumeration of all external nullifiers.
+    mapping (uint256 => bool) external_nullifiers;
+    mapping (uint256 => uint256) external_nullifiers_by_index;
+    uint256 private next_external_nullifier_index;
 
     uint8 public id_tree_index;
 
@@ -59,8 +63,8 @@ contract Semaphore is Verifier, MultipleMerkleTree, Ownable {
         _;
     }
 
-    constructor(uint8 tree_levels, uint256 zero_value, uint256 external_nullifier_in) Ownable() public {
-        external_nullifier = external_nullifier_in;
+    constructor(uint8 tree_levels, uint256 zero_value, uint256 first_external_nullifier) Ownable() public {
+        addExternalNullifier(first_external_nullifier);
         id_tree_index = init_tree(tree_levels, zero_value);
     }
 
@@ -130,7 +134,7 @@ contract Semaphore is Verifier, MultipleMerkleTree, Ownable {
     ) public view returns (bool) {
         return hasNullifier(input[1]) == false &&
             signal_hash == input[2] &&
-            external_nullifier == input[3] &&
+            hasExternalNullifier(input[3]) &&
             isInRootHistory(input[0]) &&
             verifyProof(a, b, c, input);
     }
@@ -155,7 +159,7 @@ contract Semaphore is Verifier, MultipleMerkleTree, Ownable {
 
         require(hasNullifier(input[1]) == false, "Semaphore: nullifier already seen");
         require(signal_hash == input[2], "Semaphore: signal hash mismatch");
-        require(external_nullifier == input[3], "Semaphore: external nullifier mismatch");
+        require(hasExternalNullifier(input[3]), "Semaphore: external nullifier mismatch");
         require(isInRootHistory(input[0]), "Semaphore: root not seen");
         require(verifyProof(a, b, c, input), "Semaphore: invalid proof");
         _;
@@ -176,13 +180,15 @@ contract Semaphore is Verifier, MultipleMerkleTree, Ownable {
         uint[2] memory c,
         uint[4] memory input // (root, nullifiers_hash, signal_hash, external_nullifier)
     ) public 
-    onlyOwnerIfPermissioned
-    isValidSignalAndProof(signal, a, b, c, input)
+        onlyOwnerIfPermissioned
+        isValidSignalAndProof(signal, a, b, c, input)
     {
         uint nullifiers_hash = input[1];
+
         signals[current_signal_index++] = signal;
         nullifier_hash_history[nullifiers_hash] = true;
-        emit SignalBroadcast(signal, nullifiers_hash, external_nullifier);
+
+        emit SignalBroadcast(signal, nullifiers_hash, input[3]);
     }
 
     /*
@@ -218,11 +224,42 @@ contract Semaphore is Verifier, MultipleMerkleTree, Ownable {
     }
 
     /*
-     * Sets a new external nullifier for the contract. Only the owner can do this.
+     * Adds an external nullifier to the contract. Only the owner can do this.
      * @param new_external_nullifier The new external nullifier to set
      */
-    function setExternalNullifier(uint256 new_external_nullifier) public onlyOwner {
-      external_nullifier = new_external_nullifier;
+    function addExternalNullifier(uint256 _external_nullifier) public onlyOwner {
+        // The external nullifier must not have already been set
+        require(external_nullifiers[_external_nullifier] == false, "Semaphore: external nullifier already set");
+
+        // Add a new external nullifier
+        external_nullifiers[_external_nullifier] = true;
+        external_nullifiers_by_index[next_external_nullifier_index] = _external_nullifier;
+
+        // Update the next index
+        next_external_nullifier_index += 1;
+    }
+
+    /*
+     * Returns the next external nullifier index.
+     */
+    function getNextExternalNullifierIndex() public view returns (uint256) {
+        return next_external_nullifier_index;
+    }
+
+    /*
+     * Returns the external nullifier at _index.
+     * @param _index The index to use to look up the external_nullifiers_by_index mapping
+     */
+    function getExternalNullifierByIndex(uint256 _index) public view returns (uint256) {
+        return external_nullifiers_by_index[_index];
+    }
+
+    /*
+     * Returns true if and only if the specified external nullifier exists
+     * @param _external_nullifier The specified external nullifier
+     */
+    function hasExternalNullifier(uint256 _external_nullifier) public view returns (bool) {
+        return external_nullifiers[_external_nullifier];
     }
 
     /*

--- a/semaphorejs/package-lock.json
+++ b/semaphorejs/package-lock.json
@@ -1866,9 +1866,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30000989",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw=="
+      "version": "1.0.30000997",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000997.tgz",
+      "integrity": "sha512-BQLFPIdj2ntgBNWp9Q64LGUIEmvhKkzzHhUHR3CD5A9Lb7ZKF20/+sgadhFap69lk5XmK1fTUleDclaRFvgVUA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -1985,27 +1985,28 @@
       }
     },
     "circomlib": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/circomlib/-/circomlib-0.0.13.tgz",
-      "integrity": "sha512-QHCSOzVT42shVK6goSyZkbEyZa9WTsdfYHkxSDypBj+fKM1gJCms3NQ+PT/v/f/8lwZye2KDMM0B8IsvC9pMrA==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/circomlib/-/circomlib-0.0.18.tgz",
+      "integrity": "sha512-A06u7fEYlUb/NoRguYSkxDcPfAcqHJ23UnZ1jsj4l581C4Q4i7NC0MwsYOOPDnhXqk1t3/LjDFzN3dIhPyfiCQ==",
       "requires": {
         "blake-hash": "^1.1.0",
         "blake2b": "^2.1.3",
-        "snarkjs": "0.1.11",
+        "snarkjs": "^0.1.20",
         "typedarray-to-buffer": "^3.1.5",
         "web3": "^1.0.0-beta.55"
       },
       "dependencies": {
         "snarkjs": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.1.11.tgz",
-          "integrity": "sha512-NoMNn03Uwbt18V340ZlHSZscyfIu8F6fMOL7LT9Xr1zQY/nmzScM8442ATyJfzSI5bDTAz1QQGbCerP2BCKljA==",
+          "version": "0.1.20",
+          "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.1.20.tgz",
+          "integrity": "sha512-tYmWiVm1sZiB44aIh5w/3HUaTntTUC4fv+CWs4rR0gfkt2KbHTpArOqZW++/Lxujrn9IypXVhdKVUr/eE6Hxfg==",
           "requires": {
-            "big-integer": "^1.6.35",
-            "chai": "^4.1.2",
+            "big-integer": "^1.6.43",
+            "chai": "^4.2.0",
             "escape-string-regexp": "^1.0.5",
-            "eslint": "^5.3.0",
-            "yargs": "^12.0.2"
+            "eslint": "^5.16.0",
+            "keccak": "^2.0.0",
+            "yargs": "^12.0.5"
           }
         }
       }
@@ -2947,9 +2948,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.238",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.238.tgz",
-      "integrity": "sha512-k+s6EIiSTgfOm7WiMlGBMMMtBQXSui8OfLN1sXU3RohJOuLGVq0lVm7hXyDIDBcbPM0MeZabAdIPQOSEZT3ZLg=="
+      "version": "1.3.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.267.tgz",
+      "integrity": "sha512-9Q2ixAJC+oHjWNtJV0MQ4vJMCWSowIrC6V6vcr+bwPddTDHj2ddv9xxXCzf4jT/fy6HP7maPoW0gifXkRxCttQ=="
     },
     "elliptic": {
       "version": "6.3.3",
@@ -3322,15 +3323,14 @@
       }
     },
     "eth-json-rpc-infura": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.0.tgz",
-      "integrity": "sha512-FLcpdxPRVBCUc7yoE+wHGvyYg2lATedP+/q7PsKvaSzQpJbgTG4ZjLnyrLanxDr6M1k/dSNa6V5QnILwjUKJcw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.1.tgz",
+      "integrity": "sha512-W7zR4DZvyTn23Bxc0EWsq4XGDdD63+XPUCEhV2zQvQGavDVC4ZpFDK4k99qN7bd7/fjj37+rxmuBOBeIqCA5Mw==",
       "requires": {
         "cross-fetch": "^2.1.1",
         "eth-json-rpc-middleware": "^1.5.0",
         "json-rpc-engine": "^3.4.0",
-        "json-rpc-error": "^2.0.0",
-        "tape": "^4.8.0"
+        "json-rpc-error": "^2.0.0"
       }
     },
     "eth-json-rpc-middleware": {
@@ -3424,7 +3424,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
@@ -3594,9 +3594,9 @@
       }
     },
     "ethereumjs-common": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.1.tgz",
-      "integrity": "sha512-kexqNgM2q29RKoZPPjehPREeqbr/vhYfT9Ho8FVeH3f7USjBuYp1iZ1qjqklk8FSMvEKPpMJFYSOunikw30Prw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.2.tgz",
+      "integrity": "sha512-GkltYRIqBLzaZLmF/K3E+g9lZ4O4FL+TtpisAlD3N+UVlR+mrtoG+TvxavqVa6PwOY4nKIEMe5pl6MrTio3Lww=="
     },
     "ethereumjs-tx": {
       "version": "1.3.7",
@@ -4489,7 +4489,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4507,11 +4508,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4524,15 +4527,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4635,7 +4641,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4645,6 +4652,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4657,17 +4665,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4684,6 +4695,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4756,7 +4768,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4766,6 +4779,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4841,7 +4855,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4871,6 +4886,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4888,6 +4904,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4926,11 +4943,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -5774,6 +5793,7 @@
           "version": "1.3.7",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
           "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+          "optional": true,
           "requires": {
             "mime-types": "~2.1.24",
             "negotiator": "0.6.2"
@@ -5782,12 +5802,14 @@
             "mime-db": {
               "version": "1.40.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-              "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+              "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+              "optional": true
             },
             "mime-types": {
               "version": "2.1.24",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
               "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+              "optional": true,
               "requires": {
                 "mime-db": "1.40.0"
               }
@@ -5864,7 +5886,8 @@
         "any-promise": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-          "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+          "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+          "optional": true
         },
         "anymatch": {
           "version": "2.0.0",
@@ -5929,7 +5952,8 @@
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "optional": true
         },
         "array-union": {
           "version": "1.0.2",
@@ -6800,6 +6824,7 @@
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -6828,6 +6853,7 @@
           "version": "1.19.0",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "content-type": "~1.0.4",
@@ -6845,6 +6871,7 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -6853,6 +6880,7 @@
               "version": "0.4.24",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+              "optional": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
@@ -6860,7 +6888,8 @@
             "qs": {
               "version": "6.7.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-              "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+              "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+              "optional": true
             }
           }
         },
@@ -7035,6 +7064,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -7043,7 +7073,8 @@
         "buffer-alloc-unsafe": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+          "optional": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -7054,7 +7085,8 @@
         "buffer-fill": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+          "optional": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -7064,7 +7096,8 @@
         "buffer-to-arraybuffer": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-          "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
+          "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
+          "optional": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -7079,7 +7112,8 @@
         "bytes": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+          "optional": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -7489,6 +7523,7 @@
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
           "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+          "optional": true,
           "requires": {
             "safe-buffer": "5.1.2"
           }
@@ -7496,7 +7531,8 @@
         "content-type": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+          "optional": true
         },
         "convert-source-map": {
           "version": "1.6.0",
@@ -7509,17 +7545,20 @@
         "cookie": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+          "optional": true
         },
         "cookie-signature": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+          "optional": true
         },
         "cookiejar": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-          "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+          "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+          "optional": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
@@ -7553,6 +7592,7 @@
           "version": "2.8.5",
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
           "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+          "optional": true,
           "requires": {
             "object-assign": "^4",
             "vary": "^1"
@@ -7787,6 +7827,7 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -7795,6 +7836,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -8002,7 +8044,8 @@
         "depd": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "optional": true
         },
         "des.js": {
           "version": "1.0.0",
@@ -8016,7 +8059,8 @@
         "destroy": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+          "optional": true
         },
         "detect-indent": {
           "version": "4.0.0",
@@ -8072,7 +8116,8 @@
         "duplexer3": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+          "optional": true
         },
         "duplexify": {
           "version": "3.7.1",
@@ -8097,7 +8142,8 @@
         "ee-first": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+          "optional": true
         },
         "electron-to-chromium": {
           "version": "1.3.113",
@@ -8136,7 +8182,8 @@
         "encodeurl": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+          "optional": true
         },
         "encoding": {
           "version": "0.1.12",
@@ -8240,7 +8287,8 @@
         "escape-html": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -8598,7 +8646,8 @@
         "etag": {
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+          "optional": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -8676,6 +8725,7 @@
           "version": "0.1.27",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
           "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+          "optional": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -9210,6 +9260,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -9218,7 +9269,8 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+              "optional": true
             }
           }
         },
@@ -9234,7 +9286,8 @@
         "eventemitter3": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
+          "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
+          "optional": true
         },
         "events": {
           "version": "3.0.0",
@@ -9318,6 +9371,7 @@
           "version": "4.17.1",
           "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
           "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+          "optional": true,
           "requires": {
             "accepts": "~1.3.7",
             "array-flatten": "1.1.1",
@@ -9355,6 +9409,7 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -9362,7 +9417,8 @@
             "qs": {
               "version": "6.7.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-              "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+              "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+              "optional": true
             }
           }
         },
@@ -9545,7 +9601,8 @@
         "file-type": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "optional": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -9582,6 +9639,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
           "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "encodeurl": "~1.0.2",
@@ -9596,6 +9654,7 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -9711,7 +9770,8 @@
         "forwarded": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+          "optional": true
         },
         "fragment-cache": {
           "version": "0.2.1",
@@ -9724,7 +9784,8 @@
         "fresh": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+          "optional": true
         },
         "from2": {
           "version": "2.3.0",
@@ -9738,12 +9799,14 @@
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+          "optional": true
         },
         "fs-extra": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0"
@@ -9794,7 +9857,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9812,11 +9876,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9829,15 +9895,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9940,7 +10009,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9950,6 +10020,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9962,17 +10033,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9989,6 +10063,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -10061,7 +10136,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -10071,6 +10147,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -10146,7 +10223,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10176,6 +10254,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10193,6 +10272,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10231,11 +10311,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -10243,6 +10325,7 @@
           "version": "1.0.12",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
           "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -10293,7 +10376,8 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "optional": true
         },
         "get-value": {
           "version": "2.0.6",
@@ -10382,6 +10466,7 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+          "optional": true,
           "requires": {
             "decompress-response": "^3.2.0",
             "duplexer3": "^0.1.4",
@@ -10481,7 +10566,8 @@
         "has-symbol-support-x": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-          "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+          "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+          "optional": true
         },
         "has-symbols": {
           "version": "1.0.0",
@@ -10492,6 +10578,7 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
           "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+          "optional": true,
           "requires": {
             "has-symbol-support-x": "^1.4.1"
           }
@@ -10600,6 +10687,7 @@
           "version": "1.7.2",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -10611,7 +10699,8 @@
         "http-https": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-          "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
+          "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
+          "optional": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -10935,7 +11024,8 @@
         "ipaddr.js": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+          "optional": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
@@ -11112,7 +11202,8 @@
         "is-object": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-          "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+          "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+          "optional": true
         },
         "is-observable": {
           "version": "1.1.0",
@@ -11146,7 +11237,8 @@
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+          "optional": true
         },
         "is-plain-object": {
           "version": "2.0.4",
@@ -11182,7 +11274,8 @@
         "is-retry-allowed": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+          "optional": true
         },
         "is-stream": {
           "version": "1.1.0",
@@ -11353,6 +11446,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+          "optional": true,
           "requires": {
             "has-to-string-tag-x": "^1.2.0",
             "is-object": "^1.0.1"
@@ -12066,7 +12160,8 @@
         "lowercase-keys": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+          "optional": true
         },
         "lru-cache": {
           "version": "3.2.0",
@@ -12143,7 +12238,8 @@
         "media-typer": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+          "optional": true
         },
         "mem": {
           "version": "4.1.0",
@@ -12195,7 +12291,8 @@
         "merge-descriptors": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+          "optional": true
         },
         "merge-source-map": {
           "version": "1.1.0",
@@ -12264,7 +12361,8 @@
         "methods": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -12298,7 +12396,8 @@
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "optional": true
         },
         "mime-db": {
           "version": "1.38.0",
@@ -12321,7 +12420,8 @@
         "mimic-response": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+          "optional": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -12523,7 +12623,8 @@
         "nano-json-stream-parser": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
-          "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+          "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
+          "optional": true
         },
         "nanomatch": {
           "version": "1.2.13",
@@ -12551,7 +12652,8 @@
         "negotiator": {
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+          "optional": true
         },
         "neo-async": {
           "version": "2.6.0",
@@ -12704,6 +12806,7 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -12712,7 +12815,8 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+              "optional": true
             }
           }
         },
@@ -13029,6 +13133,7 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
           "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
+          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -13037,6 +13142,7 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -13112,7 +13218,8 @@
         "p-cancelable": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+          "optional": true
         },
         "p-defer": {
           "version": "1.0.0",
@@ -13154,6 +13261,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -13222,7 +13330,8 @@
         "parseurl": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-          "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+          "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+          "optional": true
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -13270,7 +13379,8 @@
         "path-to-regexp": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "optional": true
         },
         "path-type": {
           "version": "1.1.0",
@@ -13404,7 +13514,8 @@
         "prepend-http": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "optional": true
         },
         "prettier": {
           "version": "1.16.4",
@@ -13454,6 +13565,7 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
           "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+          "optional": true,
           "requires": {
             "forwarded": "~0.1.2",
             "ipaddr.js": "1.9.0"
@@ -13582,6 +13694,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -13618,17 +13731,20 @@
         "randomhex": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
-          "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU="
+          "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
+          "optional": true
         },
         "range-parser": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+          "optional": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -13640,6 +13756,7 @@
               "version": "0.4.24",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+              "optional": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
@@ -14073,6 +14190,7 @@
           "version": "0.17.1",
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -14093,6 +14211,7 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -14100,14 +14219,16 @@
                 "ms": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                  "optional": true
                 }
               }
             },
             "ms": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "optional": true
             }
           }
         },
@@ -14120,6 +14241,7 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
           "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+          "optional": true,
           "requires": {
             "encodeurl": "~1.0.2",
             "escape-html": "~1.0.3",
@@ -14131,6 +14253,7 @@
           "version": "0.1.12",
           "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
           "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+          "optional": true,
           "requires": {
             "body-parser": "^1.16.0",
             "cors": "^2.8.1",
@@ -14178,7 +14301,8 @@
         "setprototypeof": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+          "optional": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -14225,12 +14349,14 @@
         "simple-concat": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+          "optional": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -14567,7 +14693,8 @@
         "statuses": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "optional": true
         },
         "stream-browserify": {
           "version": "2.0.2",
@@ -14623,7 +14750,8 @@
         "strict-uri-encode": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "optional": true
         },
         "string-argv": {
           "version": "0.0.2",
@@ -14832,6 +14960,7 @@
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -15006,6 +15135,7 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
           "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+          "optional": true,
           "requires": {
             "any-promise": "^1.0.0"
           }
@@ -15014,6 +15144,7 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
           "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+          "optional": true,
           "requires": {
             "thenify": ">= 3.1.0 < 4"
           }
@@ -15035,7 +15166,8 @@
         "timed-out": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+          "optional": true
         },
         "timers-browserify": {
           "version": "2.0.10",
@@ -15061,7 +15193,8 @@
         "to-buffer": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-          "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+          "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+          "optional": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -15109,7 +15242,8 @@
         "toidentifier": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-          "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+          "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+          "optional": true
         },
         "toposort": {
           "version": "2.0.2",
@@ -15182,6 +15316,7 @@
           "version": "1.6.18",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
@@ -15190,12 +15325,14 @@
             "mime-db": {
               "version": "1.40.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-              "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+              "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+              "optional": true
             },
             "mime-types": {
               "version": "2.1.24",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
               "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+              "optional": true,
               "requires": {
                 "mime-db": "1.40.0"
               }
@@ -15267,7 +15404,8 @@
         "ultron": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+          "optional": true
         },
         "unbzip2-stream": {
           "version": "1.3.3",
@@ -15282,7 +15420,8 @@
         "underscore": {
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "optional": true
         },
         "union-value": {
           "version": "1.0.0",
@@ -15340,7 +15479,8 @@
         "unpipe": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+          "optional": true
         },
         "unset-value": {
           "version": "1.0.0",
@@ -15421,6 +15561,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "optional": true,
           "requires": {
             "prepend-http": "^1.0.1"
           }
@@ -15428,12 +15569,14 @@
         "url-set-query": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-          "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
+          "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
+          "optional": true
         },
         "url-to-options": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-          "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+          "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+          "optional": true
         },
         "use": {
           "version": "3.1.1",
@@ -15469,7 +15612,8 @@
         "utils-merge": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+          "optional": true
         },
         "uuid": {
           "version": "3.3.2",
@@ -15493,7 +15637,8 @@
         "vary": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+          "optional": true
         },
         "verror": {
           "version": "1.10.0",
@@ -15553,6 +15698,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.35.tgz",
           "integrity": "sha512-ayGavbgVk4KL9Y88Uv411fBJ0SVgVfKhKEBweKYzmP0zOqneMzWt6YsyD1n6kRvjAbqA0AfUPEOKyMNjcx2tjw==",
+          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -15564,6 +15710,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz",
           "integrity": "sha512-APOu3sEsamyqWt//8o4yq9KF25/uqGm+pQShson/sC4gKzmfJB07fLo2ond0X30E8fIqAPeVCotPXQxGciGUmA==",
+          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-eth-iban": "1.0.0-beta.35",
@@ -15574,6 +15721,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.35.tgz",
           "integrity": "sha512-jidImCide8q0GpfsO4L73qoHrbkeWgwU3uOH5DKtJtv0ccmG086knNMRgryb/o9ZgetDWLmDEsJnHjBSoIwcbA==",
+          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -15586,6 +15734,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz",
           "integrity": "sha512-GvqXqKq07OmHuVi5uNRg6k79a1/CI0ViCC+EtNv4CORHtDRmYEt5Bvdv6z6FJEiaaQkD0lKbFwNhLxutx7HItw==",
+          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "1.1.1"
@@ -15595,6 +15744,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.35.tgz",
           "integrity": "sha512-S+zW2h17ZZQU9oe3yaCJE0E7aJS4C3Kf4kGPDv+nXjW0gKhQQhgVhw1Doq/aYQGqNSWJp7f1VHkz5gQWwg6RRg==",
+          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -15607,6 +15757,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz",
           "integrity": "sha512-gXzLrWvcGkGiWq1y33Z4Y80XI8XMrwowiQJkrPSjQ81K5PBKquOGwcMffLaKcwdmEy/NpsOXDeFo3eLE1Ghvvw==",
+          "optional": true,
           "requires": {
             "eventemitter3": "1.1.1",
             "underscore": "1.8.3",
@@ -15637,6 +15788,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz",
           "integrity": "sha512-KUDC+EtFFYG8z01ZleKrASdjj327/rtWHzEt6RWsEj7bBa0bGp9nEh+nqdZx/Sdgz1O8tnfFzJlrRcXpfr1vGg==",
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "underscore": "1.8.3",
@@ -15647,7 +15799,8 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+              "optional": true
             }
           }
         },
@@ -15718,6 +15871,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
           "integrity": "sha512-H5wkcNcAIc+h/WoDIKv7ZYmrM2Xqu3O7jBQl1IWo73EDVQji+AoB2i3J8tuwI1yZRInRwrfpI3Zuwuf54hXHmQ==",
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "web3-utils": "1.0.0-beta.35"
@@ -15726,7 +15880,8 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+              "optional": true
             }
           }
         },
@@ -15734,6 +15889,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.35.tgz",
           "integrity": "sha512-AcM9nnlxu7ZRRxPvkrFB9eLxMM4A2cPfj2aCg21Wb2EpMnhR+b/O1cT33k7ApRowoMpM+T9M8vx2oPNwXfaCOQ==",
+          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -15746,6 +15902,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.35.tgz",
           "integrity": "sha512-bbwaQ/KohGjIJ6HAKbZ6KrklCAaG6/B7hIbAbVLSFLxF+Yz9lmAgQYaDInpidpC/NLb3WOmcbRF+P77J4qMVIA==",
+          "optional": true,
           "requires": {
             "web3-core": "1.0.0-beta.35",
             "web3-core-method": "1.0.0-beta.35",
@@ -15852,6 +16009,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.35.tgz",
           "integrity": "sha512-DcIMFq52Fb08UpWyZ3ZlES6NsNqJnco4hBS/Ej6eOcASfuUayPI+GLkYVZsnF3cBYqlH+DOKuArcKSuIxK7jIA==",
+          "optional": true,
           "requires": {
             "web3-core-helpers": "1.0.0-beta.35",
             "xhr2-cookies": "1.1.0"
@@ -15861,6 +16019,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz",
           "integrity": "sha512-iB0FG0HcpUnayfa8pn4guqEQ4Y1nrroi/jffdtQgFkrNt0sD3fMSwwC0AbmECqj3tDLl0e1slBR0RENll+ZF0g==",
+          "optional": true,
           "requires": {
             "oboe": "2.1.3",
             "underscore": "1.8.3",
@@ -15871,6 +16030,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz",
           "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
+          "optional": true,
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.35",
@@ -15881,6 +16041,7 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -15888,6 +16049,7 @@
             "websocket": {
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
               "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "optional": true,
               "requires": {
                 "debug": "^2.2.0",
                 "nan": "^2.3.3",
@@ -15913,6 +16075,7 @@
           "version": "1.0.0-beta.35",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.35.tgz",
           "integrity": "sha512-Dq6f0SOKj3BDFRgOPnE6ALbzBDCKVIW8mKWVf7tGVhTDHf+wQaWwQSC3aArFSqdExB75BPBPyDpuMTNszhljpA==",
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "eth-lib": "0.1.27",
@@ -15926,12 +16089,14 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+              "optional": true
             },
             "utf8": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-              "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
+              "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
+              "optional": true
             }
           }
         },
@@ -16273,6 +16438,7 @@
           "version": "3.3.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "optional": true,
           "requires": {
             "async-limiter": "~1.0.0",
             "safe-buffer": "~5.1.0",
@@ -16294,6 +16460,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -16308,6 +16475,7 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+          "optional": true,
           "requires": {
             "xhr-request": "^1.0.1"
           }
@@ -16316,6 +16484,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }
@@ -20298,6 +20467,34 @@
         "await-lock": "^1.1.3",
         "circomlib": "0.0.13",
         "snarkjs": "0.1.17"
+      },
+      "dependencies": {
+        "circomlib": {
+          "version": "0.0.13",
+          "resolved": "https://registry.npmjs.org/circomlib/-/circomlib-0.0.13.tgz",
+          "integrity": "sha512-QHCSOzVT42shVK6goSyZkbEyZa9WTsdfYHkxSDypBj+fKM1gJCms3NQ+PT/v/f/8lwZye2KDMM0B8IsvC9pMrA==",
+          "requires": {
+            "blake-hash": "^1.1.0",
+            "blake2b": "^2.1.3",
+            "snarkjs": "0.1.11",
+            "typedarray-to-buffer": "^3.1.5",
+            "web3": "^1.0.0-beta.55"
+          },
+          "dependencies": {
+            "snarkjs": {
+              "version": "0.1.11",
+              "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.1.11.tgz",
+              "integrity": "sha512-NoMNn03Uwbt18V340ZlHSZscyfIu8F6fMOL7LT9Xr1zQY/nmzScM8442ATyJfzSI5bDTAz1QQGbCerP2BCKljA==",
+              "requires": {
+                "big-integer": "^1.6.35",
+                "chai": "^4.1.2",
+                "escape-string-regexp": "^1.0.5",
+                "eslint": "^5.3.0",
+                "yargs": "^12.0.2"
+              }
+            }
+          }
+        }
       }
     },
     "semver": {
@@ -21648,7 +21845,7 @@
       "integrity": "sha512-9L4gtNQRa8pQOD4Z8bVh/6/n+sVQ+ZDKtL2UkKOWzm+IrlCRScLBaePJLCfU0dveTV1LZvmzUsliUHB3Cf2qQw==",
       "requires": {
         "ethereumjs-wallet": "^0.6.3",
-        "web3-provider-engine": "git+https://github.com/trufflesuite/provider-engine.git#3538c60bc4836b73ccae1ac3f64c8fed8ef19c1a"
+        "web3-provider-engine": "git+https://github.com/trufflesuite/provider-engine.git#web3-one"
       }
     },
     "tslib": {
@@ -22466,7 +22663,7 @@
       "requires": {
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.0",
-        "websocket": "github:frozeman/WebSocket-Node#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "github:frozeman/WebSocket-Node#browserifyCompatible"
       }
     },
     "web3-shh": {

--- a/semaphorejs/package.json
+++ b/semaphorejs/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "truffle test --network=local",
+    "test-semaphore": "truffle test --network=local test/contracts/semaphore.js",
     "migrate": "truffle migrate --network=local",
     "npm-update-git-deps": "npm-update-git-deps"
   },

--- a/semaphorejs/test/contracts/semaphore.js
+++ b/semaphorejs/test/contracts/semaphore.js
@@ -79,10 +79,13 @@ const cutDownBits = function(b, bits) {
 
 const cirDef = JSON.parse(fs.readFileSync(path.join(__dirname,'../../build/circuit.json')).toString());
 const circuit = new snarkjs.Circuit(cirDef);
+const vk_proof = fs.readFileSync(path.join(__dirname,'../../build/proving_key.bin'));
+
+const new_external_nullifier = bigInt('1234569876');
+let identity_commitments = []
 
 contract('Semaphore', function (accounts) {
     let semaphore;
-    let identity_commitment1;
 
     before(async () => {
         semaphore = await Semaphore.deployed();
@@ -99,7 +102,7 @@ contract('Semaphore', function (accounts) {
         const pubKey = eddsa.prv2pub(prvKey);
 
         const external_nullifier = bigInt('12312');
-        const signal_str = 'hello!';
+        const signal_str = 'proof ' + Date.now().toString();
         const signal_to_contract = web3.utils.asciiToHex(signal_str);
         const signal_to_contract_bytes = new Buffer(signal_to_contract.slice(2), 'hex');
 
@@ -146,15 +149,19 @@ contract('Semaphore', function (accounts) {
         );
 
         const identity_commitment = pedersenHash([bigInt(circomlib.babyJub.mulPointEscalar(pubKey, 8)[0]), bigInt(identity_nullifier), bigInt(identity_trapdoor)]);
-        identity_commitment1 = identity_commitment;
+        identity_commitments.push(identity_commitment)
 
         const semaphore = await Semaphore.deployed();
         const receipt = await semaphore.insertIdentity(identity_commitment.toString());
         assert.equal(receipt.logs[0].event, 'LeafAdded');
         const next_index = parseInt(receipt.logs[0].args.leaf_index.toString());
 
-        await tree.update(next_index, identity_commitment.toString());
-        await memTree.update(next_index, identity_commitment.toString());
+        for (let i=0; i < identity_commitments.length; i++) {
+          const idc = identity_commitments[i];
+          await tree.update(next_index, idc.toString());
+          await memTree.update(next_index, idc.toString());
+        }
+
         const identity_path = await tree.path(next_index);
         const mem_identity_path = await memTree.path(next_index);
 
@@ -195,7 +202,6 @@ contract('Semaphore', function (accounts) {
         //console.log(w[circuit.getSignalIdx('main.nullifiers_hash')]);
         //console.log(w[circuit.getSignalIdx('main.identity_commitment.out')]);
 
-        const vk_proof = fs.readFileSync(path.join(__dirname,'../../build/proving_key.bin'));
         const witness_bin = proof_util.convertWitness(snarkjs.stringifyBigInts(w));
         const publicSignals = w.slice(1, circuit.nPubInputs + circuit.nOutputs+1);
         const proof = await proof_util.prove(witness_bin.buffer, vk_proof.buffer);
@@ -258,13 +264,12 @@ contract('Semaphore', function (accounts) {
         //console.log(evs);
     });
 
-    it('test with an additional external nullifier', async () => {
-        const prvKey = Buffer.from('0001020304050607080900010203040506070809000102030405060708090001', 'hex');
+    it('test adding an external nullifier and broadcasting a signal to it', async () => {
+        const prvKey = Buffer.from('0001020304050607080900010203040506070809000102030405060708090002', 'hex');
 
         const pubKey = eddsa.prv2pub(prvKey);
 
-        const external_nullifier = bigInt('1234569876');
-        const signal_str = 'hello, world!';
+        const signal_str = 'adding en ' + Date.now().toString();
         const signal_to_contract = web3.utils.asciiToHex(signal_str);
         const signal_to_contract_bytes = new Buffer(signal_to_contract.slice(2), 'hex');
 
@@ -277,7 +282,7 @@ contract('Semaphore', function (accounts) {
 
         const accounts = await web3.eth.getAccounts();
 
-        const msg = mimcsponge.multiHash([bigInt(external_nullifier), bigInt(signal_hash)]);
+        const msg = mimcsponge.multiHash([bigInt(new_external_nullifier), bigInt(signal_hash)]);
         const signature = eddsa.signMiMCSponge(prvKey, msg);
 
         assert(eddsa.verifyMiMCSponge(msg, signature, pubKey));
@@ -299,19 +304,22 @@ contract('Semaphore', function (accounts) {
         );
 
         const identity_commitment = pedersenHash([bigInt(circomlib.babyJub.mulPointEscalar(pubKey, 8)[0]), bigInt(identity_nullifier), bigInt(identity_trapdoor)]);
-        identity_commitment1 = identity_commitment;
+        identity_commitments.push(identity_commitment)
 
         const semaphore = await Semaphore.deployed();
-        await semaphore.addExternalNullifier(external_nullifier.toString())
-        assert.isTrue(await semaphore.hasExternalNullifier(external_nullifier.toString()))
+        await semaphore.addExternalNullifier(new_external_nullifier.toString())
+        assert.isTrue(await semaphore.hasExternalNullifier(new_external_nullifier.toString()))
 
         const receipt = await semaphore.insertIdentity(identity_commitment.toString());
         assert.equal(receipt.logs[0].event, 'LeafAdded');
         const next_index = parseInt(receipt.logs[0].args.leaf_index.toString());
 
-        await memTree.update(next_index, identity_commitment.toString());
-        const mem_identity_path = await memTree.path(next_index);
+        for (let i=0; i < identity_commitments.length; i++) {
+          const idc = identity_commitments[i];
+          await memTree.update(i, idc.toString());
+        }
 
+        const mem_identity_path = await memTree.path(next_index);
         const identity_path_elements = mem_identity_path.path_elements;
         const identity_path_index = mem_identity_path.path_index;
 
@@ -322,7 +330,108 @@ contract('Semaphore', function (accounts) {
             'auth_sig_r[1]': signature.R8[1],
             auth_sig_s: signature.S,
             signal_hash,
-            external_nullifier,
+            external_nullifier: new_external_nullifier,
+            identity_nullifier,
+            identity_trapdoor,
+            identity_path_elements,
+            identity_path_index,
+            fake_zero: bigInt(0),
+        });
+
+        assert(circuit.checkWitness(w));
+
+        const root = w[circuit.getSignalIdx('main.root')];
+        assert.equal(w[circuit.getSignalIdx('main.root')].toString(), mem_identity_path.root);
+
+        const witness_bin = proof_util.convertWitness(snarkjs.stringifyBigInts(w));
+        const publicSignals = w.slice(1, circuit.nPubInputs + circuit.nOutputs+1);
+        const proof = await proof_util.prove(witness_bin.buffer, vk_proof.buffer);
+
+        const a = [ proof.pi_a[0].toString(), proof.pi_a[1].toString() ]
+        const b = [ [ proof.pi_b[0][1].toString(), proof.pi_b[0][0].toString() ], [ proof.pi_b[1][1].toString(), proof.pi_b[1][0].toString() ] ]
+        const c = [ proof.pi_c[0].toString(), proof.pi_c[1].toString() ]
+        const input = publicSignals.map((x) => x.toString())
+
+        // comment this out to debug preBroadcastCheck using the revert reasons
+        // in isValidSignalAndProof
+ 
+        //const check = await semaphore.preBroadcastCheck(a, b, c, input, bigInt(signal_hash).toString())
+        //assert.isTrue(check)
+
+        const broadcastTx = await semaphore.broadcastSignal(
+            signal_to_contract, a, b, c, input,
+        );
+
+        assert.isTrue(broadcastTx.receipt.status)
+    });
+
+    it('test removing an external nullifier and broadcasting a signal to it', async () => {
+        const prvKey = Buffer.from('0001020304050607080900010203040506070809000102030405060708090003', 'hex');
+
+        const pubKey = eddsa.prv2pub(prvKey);
+
+        const signal_str = 'removing en ' + Date.now().toString();
+        const signal_to_contract = web3.utils.asciiToHex(signal_str);
+        const signal_to_contract_bytes = new Buffer(signal_to_contract.slice(2), 'hex');
+
+        const signal_hash_raw = ethers.utils.solidityKeccak256(
+            ['bytes'],
+            [signal_to_contract_bytes],
+        );
+        const signal_hash_raw_bytes = new Buffer(signal_hash_raw.slice(2), 'hex');
+        const signal_hash = beBuff2int(signal_hash_raw_bytes.slice(0, 31));
+
+        const accounts = await web3.eth.getAccounts();
+
+        const msg = mimcsponge.multiHash([bigInt(new_external_nullifier), bigInt(signal_hash)]);
+        const signature = eddsa.signMiMCSponge(prvKey, msg);
+
+        assert(eddsa.verifyMiMCSponge(msg, signature, pubKey));
+
+        const identity_nullifier = bigInt('231');
+        const identity_trapdoor = bigInt('232');
+
+        const default_value = '0';
+        const memStorage = new MemStorage();
+        const hasher = new MimcSpongeHasher();
+        const prefix = 'semaphore';
+
+        const memTree = new MerkleTree(
+            prefix,
+            memStorage,
+            hasher,
+            20,
+            default_value,
+        );
+
+        const identity_commitment = pedersenHash([bigInt(circomlib.babyJub.mulPointEscalar(pubKey, 8)[0]), bigInt(identity_nullifier), bigInt(identity_trapdoor)]);
+        identity_commitments.push(identity_commitment)
+
+        const semaphore = await Semaphore.deployed();
+        await semaphore.removeExternalNullifier(new_external_nullifier.toString())
+        assert.isFalse(await semaphore.hasExternalNullifier(new_external_nullifier.toString()))
+
+        const receipt = await semaphore.insertIdentity(identity_commitment.toString());
+        assert.equal(receipt.logs[0].event, 'LeafAdded');
+        const next_index = parseInt(receipt.logs[0].args.leaf_index.toString());
+
+        for (let i=0; i < identity_commitments.length; i++) {
+          const idc = identity_commitments[i];
+          await memTree.update(i, idc.toString());
+        }
+        const identity_path = await memTree.path(next_index);
+
+        const identity_path_elements = identity_path.path_elements;
+        const identity_path_index = identity_path.path_index;
+
+        const w = circuit.calculateWitness({
+            'identity_pk[0]': pubKey[0],
+            'identity_pk[1]': pubKey[1],
+            'auth_sig_r[0]': signature.R8[0],
+            'auth_sig_r[1]': signature.R8[1],
+            auth_sig_s: signature.S,
+            signal_hash,
+            external_nullifier: new_external_nullifier,
             identity_nullifier,
             identity_trapdoor,
             identity_path_elements,
@@ -333,29 +442,33 @@ contract('Semaphore', function (accounts) {
         const root = w[circuit.getSignalIdx('main.root')];
         const nullifiers_hash = w[circuit.getSignalIdx('main.nullifiers_hash')];
         assert(circuit.checkWitness(w));
-        assert.equal(w[circuit.getSignalIdx('main.root')].toString(), mem_identity_path.root);
+        assert.equal(w[circuit.getSignalIdx('main.root')].toString(), identity_path.root);
 
-        const vk_proof = fs.readFileSync(path.join(__dirname,'../../build/proving_key.bin'));
         const witness_bin = proof_util.convertWitness(snarkjs.stringifyBigInts(w));
         const publicSignals = w.slice(1, circuit.nPubInputs + circuit.nOutputs+1);
         const proof = await proof_util.prove(witness_bin.buffer, vk_proof.buffer);
-        let failed = false;
-        let reason = '';
-
         const a = [ proof.pi_a[0].toString(), proof.pi_a[1].toString() ]
         const b = [ [ proof.pi_b[0][1].toString(), proof.pi_b[0][0].toString() ], [ proof.pi_b[1][1].toString(), proof.pi_b[1][0].toString() ] ]
         const c = [ proof.pi_c[0].toString(), proof.pi_c[1].toString() ]
-        const input = [ publicSignals[0].toString(), publicSignals[1].toString(), publicSignals[2].toString(), publicSignals[3].toString() ]
+        const input = publicSignals.map((x) => x.toString())
 
         const check = await semaphore.preBroadcastCheck(a, b, c, input, bigInt(signal_hash).toString())
-        assert.isTrue(check)
+        assert.isFalse(check)
 
-        const broadcastTx = await semaphore.broadcastSignal(
-            signal_to_contract,
-            a, b, c, input
-        );
+        let failed = false;
+        let reason = '';
 
-        assert.isTrue(broadcastTx.receipt.status)
+        try {
+          const broadcastTx = await semaphore.broadcastSignal(
+              signal_to_contract,
+              a, b, c, input
+          );
+        } catch (e) {
+          failed = true
+          reason = e.reason
+        }
+        assert.isTrue(failed)
+        assert.equal(reason, 'Semaphore: external nullifier not found');
     });
 
     it('tests permissioning', async () => {
@@ -364,7 +477,7 @@ contract('Semaphore', function (accounts) {
         const pubKey = eddsa.prv2pub(prvKey);
 
         const external_nullifier = bigInt('12312');
-        const signal_str = 'hello!';
+        const signal_str = 'permissioning ' + Date.now().toString();
         const signal_to_contract = web3.utils.asciiToHex(signal_str);
         const signal_to_contract_bytes = new Buffer(signal_to_contract.slice(2), 'hex');
 
@@ -385,22 +498,10 @@ contract('Semaphore', function (accounts) {
         const identity_nullifier = bigInt('230');
         const identity_trapdoor = bigInt('233');
 
-        const storage_path = '/tmp/rocksdb_semaphore_test';
-        if (fs.existsSync(storage_path)) {
-            del.sync(storage_path, { force: true });
-        }
         const default_value = '0';
-        const storage = new RocksDb(storage_path);
         const memStorage = new MemStorage();
         const hasher = new MimcSpongeHasher();
         const prefix = 'semaphore';
-        const tree = new MerkleTree(
-            prefix,
-            storage,
-            hasher,
-            20,
-            default_value,
-        );
 
         const memTree = new MerkleTree(
             prefix,
@@ -412,20 +513,19 @@ contract('Semaphore', function (accounts) {
 
 
         const identity_commitment = pedersenHash([bigInt(circomlib.babyJub.mulPointEscalar(pubKey, 8)[0]), bigInt(identity_nullifier), bigInt(identity_trapdoor)]);
+        identity_commitments.push(identity_commitment)
 
         const semaphore = await Semaphore.deployed();
         const receipt = await semaphore.insertIdentity(identity_commitment.toString());
         assert.equal(receipt.logs[0].event, 'LeafAdded');
         const next_index = parseInt(receipt.logs[0].args.leaf_index.toString());
 
-        await tree.update(0, identity_commitment1.toString());
-        await memTree.update(0, identity_commitment1.toString());
-        await tree.update(next_index, identity_commitment.toString());
-        await memTree.update(next_index, identity_commitment.toString());
-        const identity_path = await tree.path(next_index);
-        const mem_identity_path = await memTree.path(next_index);
+        for (let i=0; i < identity_commitments.length; i++) {
+          const idc = identity_commitments[i]
+          await memTree.update(i, idc.toString());
+        }
 
-        assert.equal(JSON.stringify(identity_path), JSON.stringify(mem_identity_path))
+        const identity_path = await memTree.path(next_index);
 
         const identity_path_elements = identity_path.path_elements;
         const identity_path_index = identity_path.path_index;
@@ -462,7 +562,6 @@ contract('Semaphore', function (accounts) {
         //console.log(w[circuit.getSignalIdx('main.nullifiers_hash')]);
         //console.log(w[circuit.getSignalIdx('main.identity_commitment.out')]);
 
-        const vk_proof = fs.readFileSync(path.join(__dirname,'../../build/proving_key.bin'));
         const witness_bin = proof_util.convertWitness(snarkjs.stringifyBigInts(w));
         const publicSignals = w.slice(1, circuit.nPubInputs + circuit.nOutputs+1);
         const proof = await proof_util.prove(witness_bin.buffer, vk_proof.buffer);

--- a/semaphorejs/test/contracts/semaphore.js
+++ b/semaphorejs/test/contracts/semaphore.js
@@ -123,22 +123,23 @@ contract('Semaphore', function (accounts) {
         const identity_nullifier = bigInt('231');
         const identity_trapdoor = bigInt('232');
 
-        const storage_path = '/tmp/rocksdb_semaphore_test';
-        if (fs.existsSync(storage_path)) {
-            del.sync(storage_path, { force: true });
-        }
+        //const storage_path = '/tmp/rocksdb_semaphore_test';
+        //if (fs.existsSync(storage_path)) {
+            //del.sync(storage_path, { force: true });
+        //}
         const default_value = '0';
-        const storage = new RocksDb(storage_path);
+        //const storage = new RocksDb(storage_path);
         const memStorage = new MemStorage();
         const hasher = new MimcSpongeHasher();
         const prefix = 'semaphore';
-        const tree = new MerkleTree(
-            prefix,
-            storage,
-            hasher,
-            20,
-            default_value,
-        );
+
+        //const tree = new MerkleTree(
+            //prefix,
+            //storage,
+            //hasher,
+            //20,
+            //default_value,
+        //);
 
         const memTree = new MerkleTree(
             prefix,
@@ -158,17 +159,17 @@ contract('Semaphore', function (accounts) {
 
         for (let i=0; i < identity_commitments.length; i++) {
           const idc = identity_commitments[i];
-          await tree.update(next_index, idc.toString());
+          //await tree.update(next_index, idc.toString());
           await memTree.update(next_index, idc.toString());
         }
 
-        const identity_path = await tree.path(next_index);
+        //const identity_path = await tree.path(next_index);
         const mem_identity_path = await memTree.path(next_index);
 
-        assert.equal(JSON.stringify(identity_path), JSON.stringify(mem_identity_path))
+        //assert.equal(JSON.stringify(identity_path), JSON.stringify(mem_identity_path))
 
-        const identity_path_elements = identity_path.path_elements;
-        const identity_path_index = identity_path.path_index;
+        const identity_path_elements = mem_identity_path.path_elements;
+        const identity_path_index = mem_identity_path.path_index;
 
         //console.log(identity_commitment.toString());
         //console.log(identity_path_elements, identity_path_index, identity_path.root);
@@ -191,7 +192,7 @@ contract('Semaphore', function (accounts) {
         const root = w[circuit.getSignalIdx('main.root')];
         const nullifiers_hash = w[circuit.getSignalIdx('main.nullifiers_hash')];
         assert(circuit.checkWitness(w));
-        assert.equal(w[circuit.getSignalIdx('main.root')].toString(), identity_path.root);
+        assert.equal(w[circuit.getSignalIdx('main.root')].toString(), mem_identity_path.root);
 
         //console.log(w[circuit.getSignalIdx('main.root')]);
 


### PR DESCRIPTION
This PR adds support for multiple external nullifiers.

The ENs are stored in the contract as such:

```
    mapping (uint256 => bool) active_external_nullifiers;
    mapping (uint256 => uint256) external_nullifier_history;
    uint256 private next_external_nullifier_history_index;
```

This allows anyone to quickly look up whether an external nullifier exists, which is needed during broadcasts. It also allows anyone to enumerate all external nullifiers by looking them up via an index. This makes it easy to implement applications like the OneOfUs anonymous poll dApp.

The tradeoff is that each EN is stored twice. I'd love to hear your thoughts on this. Thanks!