### PR TITLE
Fix npm sha3 issue by using sha3 2.0.2

### DIFF
--- a/semaphorejs/package-lock.json
+++ b/semaphorejs/package-lock.json
@@ -11594,7 +11594,12 @@
           "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
           "requires": {
             "browserify-sha3": "^0.0.4",
-            "sha3": "^1.2.2"
+            "sha3": "2.0.2"
+          },
+          "dependencies": {
+            "sha3": {
+              "version": "2.0.2"
+            }
           }
         },
         "kind-of": {
@@ -14314,11 +14319,8 @@
           }
         },
         "sha3": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
-          "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
           "requires": {
-            "nan": "2.13.2"
+            "buffer": "5.2.1"
           },
           "dependencies": {
             "nan": {
@@ -14326,7 +14328,8 @@
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
               "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
             }
-          }
+          },
+          "version": "2.0.2"
         },
         "shebang-command": {
           "version": "1.2.0",
@@ -17850,7 +17853,12 @@
       "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
       "requires": {
         "browserify-sha3": "^0.0.4",
-        "sha3": "^1.2.2"
+        "sha3": "2.0.2"
+      },
+      "dependencies": {
+        "sha3": {
+          "version": "2.0.2"
+        }
       }
     },
     "keyv": {
@@ -20623,21 +20631,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "sha3": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
-      "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
-      "requires": {
-        "nan": "2.13.2"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
-        }
       }
     },
     "shebang-command": {

--- a/semaphorejs/package.json
+++ b/semaphorejs/package.json
@@ -50,5 +50,8 @@
     "npm-update-git-deps": "^1.2.4",
     "null-loader": "^0.1.1",
     "webpack-cli": "^3.3.0"
+  },
+  "resolutions": {
+    "sha3": "2.0.2"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/kobigurk/semaphore/issues/33

Resolves to updated version of sha3 that doesn't break

See https://github.com/phusion/node-sha3/pull/33 and https://github.com/phusion/node-sha3/issues/32#issuecomment-490157571 for details