### PR TITLE
Tests updated after n_levels removed from nullifier & circom in docker option

### DIFF
--- a/circuits/semaphore-base.circom
+++ b/circuits/semaphore-base.circom
@@ -28,7 +28,6 @@ template CalculateIdentityCommitment() {
 template CalculateNullifierHash() {
     signal input external_nullifier;
     signal input identity_nullifier;
-    signal input n_levels;
 
     signal output out;
 

--- a/integration-test/integration.test.ts
+++ b/integration-test/integration.test.ts
@@ -1,10 +1,12 @@
-import { ethers } from "ethers";
-import { ZkIdentity } from "@libsem/identity";
-import { Semaphore, generateMerkleProof, genExternalNullifier, FullProof, MerkleProof } from "@libsem/protocols";
+import {expect} from "chai";
+import {ethers} from "ethers";
+import {ZkIdentity} from "@libsem/identity";
+import {FullProof, generateMerkleProof, genExternalNullifier, MerkleProof, Semaphore} from "@libsem/protocols";
+import {genNullifierHash} from "../test/helpers";
 import * as path from "path";
 import * as fs from "fs";
 
-const SemaphoreInfo = JSON.parse(fs.readFileSync("./deployments/localhost/Semaphore.json", { encoding: "utf-8"}));
+const SemaphoreInfo = JSON.parse(fs.readFileSync("./deployments/localhost/Semaphore.json", {encoding: "utf-8"}));
 const pk = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 const defaultExternalNullifier = genExternalNullifier('test-voting');
 const identityCommitments: Array<bigint> = [];
@@ -17,6 +19,11 @@ beforeAll(async () => {
     const provider = new ethers.providers.JsonRpcProvider("http://localhost:8545");
     const signer = new ethers.Wallet(pk, provider);
 
+    if (!!ethers["provider"] && !!ethers["getSigners"]) {
+        const defaultSigner = await ethers["getSigners"]()[0];
+        await defaultSigner.sendTransaction({to: signer.address, value: BigInt(1e18)});
+    }
+
     SemaphoreContract = new ethers.Contract(SemaphoreInfo.address, SemaphoreInfo.abi, provider);
     SemaphoreContract = SemaphoreContract.connect(signer);
 })
@@ -25,35 +32,34 @@ test('Should create semaphore full proof', async () => {
     const identity = new ZkIdentity();
     const identityCommitment = identity.genIdentityCommitment();
 
-    const semaphoreRootBefore = await SemaphoreContract.root();
-
     let tx = await SemaphoreContract.insertIdentity(identityCommitment);
     await tx.wait();
 
     const signal = "0x111";
-    const nullifierHash = Semaphore.genNullifierHash(defaultExternalNullifier, identity.getNullifier(), 20);
+    const nullifierHash = genNullifierHash(defaultExternalNullifier, identity.getNullifier());
 
-    const commitments = Object.assign([], identityCommitments);
-    commitments.push(identityCommitment);
+    identityCommitments.push(identityCommitment);
 
-    const merkleProof: MerkleProof = generateMerkleProof(20, ZERO_VALUE, 5, commitments, identityCommitment)
+    const merkleProof: MerkleProof = generateMerkleProof(20, ZERO_VALUE, 5, identityCommitments, identityCommitment)
     const witness = Semaphore.genWitness(identity.getIdentity(), merkleProof, defaultExternalNullifier, signal)
 
     const fullProof: FullProof = await Semaphore.genProof(witness, wasmFilePath, finalZkeyPath)
     const solidityProof = Semaphore.packToSolidityProof(fullProof);
 
     const packedProof = await SemaphoreContract.packProof(
-      solidityProof.a, 
-      solidityProof.b, 
-      solidityProof.c,
+        solidityProof.a,
+        solidityProof.b,
+        solidityProof.c,
     );
 
-    let res = null;
-    res = await SemaphoreContract.broadcastSignal(
-      ethers.utils.hexlify(ethers.utils.toUtf8Bytes(signal)),
-      packedProof,
-      merkleProof.root,
-      nullifierHash,
-      defaultExternalNullifier
-    )
-}, 60000)
+    let res = await SemaphoreContract.broadcastSignal(
+        ethers.utils.hexlify(ethers.utils.toUtf8Bytes(signal)),
+        packedProof,
+        merkleProof.root,
+        nullifierHash,
+        defaultExternalNullifier
+    );
+    expect(res).to.not.equal(null);
+    return Promise.resolve();
+
+}, 60000);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:dapp": "jest",
     "test:fullProof": "npm run compile:circuits && npm run verifier:fix && npm run test",
     "test": "npx hardhat test",
-    "compile:circuits": "scripts/build-circuits.sh <<< $'random text'",
+    "compile:circuits": "scripts/build-circuits.sh",
+    "compile:circuits:docker": "export CIRCOM_DOCKER=yes && scripts/build-circuits.sh",
     "verifier:fix": "node scripts/bump-solidity"
   },
   "repository": {

--- a/scripts/circom-docker.sh
+++ b/scripts/circom-docker.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+[[ $1 =~ (-h|--help) ]] && {
+  echo "usage: ${0##*/} <circom params>"
+  echo "e.g.:  ${0##*/} circuits/hello.circom --r1cs --wasm --sym --c --output compiled/"
+  exit 1
+}
+
+path_this=$( cd $(dirname "$0"); pwd -L )
+if [ -L "$0" ]; then
+  path_this=$(dirname $(readlink ${path_this}/$(basename "$0"))) # path relatively to the symlink file
+  [[ "$path_this" != /* ]] && path_this=$(cd $(dirname "$0")/${path_this}; pwd -L)
+fi
+
+test -t 1 && USE_TTY="-t" | USE_TTY=""
+
+docker run -i ${USE_TTY} --rm \
+  -v "${path_this}/..":/data \
+  -v /etc/passwd:/etc/passwd:ro \
+  -v /etc/group:/etc/group:ro \
+  --user $(id -u) \
+  aspiers/circom circom $@

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,8 @@
+const { poseidon } = require('circomlibjs');
+
+module.exports = {
+    // temporary replacement of @libsem/protocols.genNullifierHash that expects
+    // `n_levels` (which is no longer a part of the nullifier) as the 3rd param.
+    genNullifierHash: (externalNullifier, nullifier) =>
+        poseidon([BigInt(externalNullifier), BigInt(nullifier)]),
+}

--- a/test/semaphore-proof-test.js
+++ b/test/semaphore-proof-test.js
@@ -3,9 +3,8 @@ const {ethers } = require('hardhat');
 const { poseidon_gencontract: poseidonGenContract } = require("circomlibjs");
 const { Semaphore, generateMerkleProof, genExternalNullifier, genSignalHash } = require("@libsem/protocols");
 const { ZkIdentity } = require("@libsem/identity");
-
 const path = require("path");
-const fs = require("fs");
+const { genNullifierHash } = require("./helpers");
 
 const deployPoseidonTx = (x) => {
     return ethers.getContractFactory(
@@ -58,7 +57,7 @@ describe("Semaphore contract", () => {
       await semaphore.insertIdentity(identityCommitment);
 
       const signal = "0x111";
-      const nullifierHash = Semaphore.genNullifierHash(defaultExternalNullifier, identity.getNullifier(), 20)
+      const nullifierHash = genNullifierHash(defaultExternalNullifier, identity.getNullifier(), 20)
 
       const commitments = Object.assign([], identityCommitments)
       commitments.push(identityCommitment)
@@ -73,8 +72,8 @@ describe("Semaphore contract", () => {
       const solidityProof = Semaphore.packToSolidityProof(fullProof);
 
       const packedProof = await semaphore.packProof(
-        solidityProof.a, 
-        solidityProof.b, 
+        solidityProof.a,
+        solidityProof.b,
         solidityProof.c,
       );
 
@@ -89,8 +88,7 @@ describe("Semaphore contract", () => {
 
       expect(preBroadcastCheck).to.be.true;
 
-      let res = null;
-      res = await semaphore.broadcastSignal(
+      let res = await semaphore.broadcastSignal(
         ethers.utils.hexlify(ethers.utils.toUtf8Bytes(signal)),
         packedProof,
         merkleProof.root,


### PR DESCRIPTION
- tests updated to match removed `n_levels` from nullifiers
> `n_levels` was removed from nullifiers in circuits, but not in `@libsem/identity` which calculates nullifiers in tests
> temporary helper script added to correctly calculates `nullifierHash` 
- An option to run circom in a docker container added to ease installation
> Compiling circuits requires installed`circom`
> As an easier option to installation, `circom` may run in docker container
> (note: `compile:circuits:docker` in `package.json`)
