### PR TITLE
Cleanup Verifier.sol and make error handling consistent

### DIFF
--- a/contracts/base/SemaphoreCore.sol
+++ b/contracts/base/SemaphoreCore.sol
@@ -14,7 +14,7 @@ contract SemaphoreCore is ISemaphoreCore {
   /// It is used to prevent double-signaling.
   mapping(uint256 => bool) internal nullifierHashes;
 
-  /// @dev Asserts that no nullifier already exists and that the zero-knowledge proof is valid.
+  /// @dev Asserts that no nullifier already exists and if the zero-knowledge proof is valid.
   /// Otherwise it reverts.
   /// @param signal: Semaphore signal.
   /// @param root: Root of the Merkle tree.

--- a/contracts/base/SemaphoreCore.sol
+++ b/contracts/base/SemaphoreCore.sol
@@ -14,7 +14,7 @@ contract SemaphoreCore is ISemaphoreCore {
   /// It is used to prevent double-signaling.
   mapping(uint256 => bool) internal nullifierHashes;
 
-  /// @dev Returns true if no nullifier already exists and if the zero-knowledge proof is valid.
+  /// @dev Asserts that no nullifier already exists and that the zero-knowledge proof is valid.
   /// Otherwise it reverts.
   /// @param signal: Semaphore signal.
   /// @param root: Root of the Merkle tree.
@@ -22,14 +22,14 @@ contract SemaphoreCore is ISemaphoreCore {
   /// @param externalNullifier: External nullifier.
   /// @param proof: Zero-knowledge proof.
   /// @param verifier: Verifier address.
-  function _isValidProof(
+  function _verifyProof(
     bytes32 signal,
     uint256 root,
     uint256 nullifierHash,
     uint256 externalNullifier,
     uint256[8] calldata proof,
     IVerifier verifier
-  ) internal view returns (bool) {
+  ) internal view {
     require(!nullifierHashes[nullifierHash], "SemaphoreCore: you cannot use the same nullifier twice");
 
     uint256 signalHash = _hashSignal(signal);
@@ -40,8 +40,6 @@ contract SemaphoreCore is ISemaphoreCore {
       [proof[6], proof[7]],
       [root, nullifierHash, signalHash, externalNullifier]
     );
-
-    return true; // TODO: This is redundant
   }
 
   /// @dev Stores the nullifier hash to prevent double-signaling.

--- a/contracts/base/SemaphoreCore.sol
+++ b/contracts/base/SemaphoreCore.sol
@@ -15,7 +15,7 @@ contract SemaphoreCore is ISemaphoreCore {
   mapping(uint256 => bool) internal nullifierHashes;
 
   /// @dev Returns true if no nullifier already exists and if the zero-knowledge proof is valid.
-  /// Otherwise it returns false.
+  /// Otherwise it reverts.
   /// @param signal: Semaphore signal.
   /// @param root: Root of the Merkle tree.
   /// @param nullifierHash: Nullifier hash.
@@ -34,13 +34,14 @@ contract SemaphoreCore is ISemaphoreCore {
 
     uint256 signalHash = _hashSignal(signal);
 
-    return
-      verifier.verifyProof(
-        [proof[0], proof[1]],
-        [[proof[2], proof[3]], [proof[4], proof[5]]],
-        [proof[6], proof[7]],
-        [root, nullifierHash, signalHash, externalNullifier]
-      );
+    verifier.verifyProof(
+      [proof[0], proof[1]],
+      [[proof[2], proof[3]], [proof[4], proof[5]]],
+      [proof[6], proof[7]],
+      [root, nullifierHash, signalHash, externalNullifier]
+    );
+
+    return true; // TODO: This is redundant
   }
 
   /// @dev Stores the nullifier hash to prevent double-signaling.

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -27,6 +27,7 @@ library Pairing {
     uint256 X;
     uint256 Y;
   }
+  
   // Encoding of field elements is: X[0] * z + X[1]
   struct G2Point {
     uint256[2] X;
@@ -40,7 +41,6 @@ library Pairing {
 
   /// @return the generator of G2
   function P2() internal pure returns (G2Point memory) {
-    // Original code point
     return
       G2Point(
         [
@@ -52,16 +52,6 @@ library Pairing {
           8495653923123431417604973247489272438418190587263600148770280649306958101930
         ]
       );
-
-    /*
-        // Changed by Jordi point
-        return G2Point(
-            [10857046999023057135944570762232829481370756359578518086990519993285655852781,
-             11559732032986387107991004021392285783925812861821192530917403151452391805634],
-            [8495653923123431417604973247489272438418190587263600148770280649306958101930,
-             4082367875863433681332203403145435568316851327593401208105741076214120093531]
-        );
-*/
   }
 
   /// @return r the negation of p, i.e. p.addition(p.negate()) should be zero.

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -11,6 +11,7 @@
 //
 // 2021 Remco Bloemen
 //       cleaned up code
+//       always revert with InvalidProof on invalid proof
 //      
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.4;

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -262,7 +262,7 @@ contract Verifier {
     );
   }
 
-  function verify(uint256[] memory input, Proof memory proof) internal view returns (bool) {
+  function verify(uint256[4] memory input, Proof memory proof) internal view returns (bool) {
     uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
     VerifyingKey memory vk = verifyingKey();
     require(input.length + 1 == vk.IC.length, "verifier-bad-input");
@@ -288,10 +288,6 @@ contract Verifier {
     proof.A = Pairing.G1Point(a[0], a[1]);
     proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
     proof.C = Pairing.G1Point(c[0], c[1]);
-    uint256[] memory inputValues = new uint256[](input.length);
-    for (uint256 i = 0; i < input.length; i++) {
-      inputValues[i] = input[i];
-    }
-    return verify(inputValues, proof);
+    return verify(input, proof);
   }
 }

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -11,7 +11,8 @@
 //
 // 2021 Remco Bloemen
 //       cleaned up code
-//       always revert with InvalidProof on invalid proof
+//       added InvalidProve() error
+//       always revert with InvalidProof() on invalid proof
 //      
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.4;

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -275,7 +275,7 @@ contract Verifier {
     );
   }
 
-  function verify(uint256[] memory input, Proof memory proof) internal view returns (uint256) {
+  function verify(uint256[] memory input, Proof memory proof) internal view returns (bool) {
     uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
     VerifyingKey memory vk = verifyingKey();
     require(input.length + 1 == vk.IC.length, "verifier-bad-input");
@@ -286,10 +286,8 @@ contract Verifier {
       vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
     }
     vk_x = Pairing.addition(vk_x, vk.IC[0]);
-    if (
-      !Pairing.pairingProd4(Pairing.negate(proof.A), proof.B, vk.alfa1, vk.beta2, vk_x, vk.gamma2, proof.C, vk.delta2)
-    ) return 1;
-    return 0;
+    bool pairingCheck = Pairing.pairingProd4(Pairing.negate(proof.A), proof.B, vk.alfa1, vk.beta2, vk_x, vk.gamma2, proof.C, vk.delta2);
+    return pairingCheck;
   }
 
   /// @return r  bool true if proof is valid
@@ -307,10 +305,6 @@ contract Verifier {
     for (uint256 i = 0; i < input.length; i++) {
       inputValues[i] = input[i];
     }
-    if (verify(inputValues, proof) == 0) {
-      return true;
-    } else {
-      return false;
-    }
+    return verify(inputValues, proof);
   }
 }

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -9,7 +9,9 @@
 //      fixed linter warnings
 //      added requiere error messages
 //
-//
+// 2021 Remco Bloemen
+//       cleaned up code
+//      
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.4;
 
@@ -74,11 +76,6 @@ library Pairing {
     // solium-disable-next-line security/no-inline-assembly
     assembly {
       success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
-      // Use "invalid" to make gas estimation work
-      switch success
-      case 0 {
-        invalid()
-      }
     }
     require(success, "pairing-add-failed");
   }
@@ -94,11 +91,6 @@ library Pairing {
     // solium-disable-next-line security/no-inline-assembly
     assembly {
       success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
-      // Use "invalid" to make gas estimation work
-      switch success
-      case 0 {
-        invalid()
-      }
     }
     require(success, "pairing-mul-failed");
   }
@@ -125,11 +117,6 @@ library Pairing {
     // solium-disable-next-line security/no-inline-assembly
     assembly {
       success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
-      // Use "invalid" to make gas estimation work
-      switch success
-      case 0 {
-        invalid()
-      }
     }
     require(success, "pairing-opcode-failed");
     return out[0] != 0;

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -117,42 +117,6 @@ library Pairing {
     if (!success || out[0] != 1) revert InvalidProof();
   }
 
-  /// Convenience method for a pairing check for two pairs.
-  function pairingProd2(
-    G1Point memory a1,
-    G2Point memory a2,
-    G1Point memory b1,
-    G2Point memory b2
-  ) internal view {
-    G1Point[] memory p1 = new G1Point[](2);
-    G2Point[] memory p2 = new G2Point[](2);
-    p1[0] = a1;
-    p1[1] = b1;
-    p2[0] = a2;
-    p2[1] = b2;
-    pairingCheck(p1, p2);
-  }
-
-  /// Convenience method for a pairing check for three pairs.
-  function pairingProd3(
-    G1Point memory a1,
-    G2Point memory a2,
-    G1Point memory b1,
-    G2Point memory b2,
-    G1Point memory c1,
-    G2Point memory c2
-  ) internal view  {
-    G1Point[] memory p1 = new G1Point[](3);
-    G2Point[] memory p2 = new G2Point[](3);
-    p1[0] = a1;
-    p1[1] = b1;
-    p1[2] = c1;
-    p2[0] = a2;
-    p2[1] = b2;
-    p2[2] = c2;
-    pairingCheck(p1, p2);
-  }
-
   /// Convenience method for a pairing check for four pairs.
   function pairingProd4(
     G1Point memory a1,

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -14,12 +14,11 @@
 //       added InvalidProve() error
 //       always revert with InvalidProof() on invalid proof
 //       make Pairing strict
-//      
+//
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.4;
 
 library Pairing {
-
   error InvalidProof();
 
   // The prime q in the base field F_q for G1
@@ -88,7 +87,7 @@ library Pairing {
   /// @return r the product of a point on G1 and a scalar, i.e.
   /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
   function scalar_mul(G1Point memory p, uint256 s) internal view returns (G1Point memory r) {
-    // By EIP-196 the values p.X and p.Y are verified to less than the BASE_MODULUS and 
+    // By EIP-196 the values p.X and p.Y are verified to less than the BASE_MODULUS and
     // form a valid point on the curve. But the scalar is not verified, so we do that explicitelly.
     if (s >= SCALAR_MODULUS) revert InvalidProof();
     uint256[3] memory input;
@@ -226,7 +225,7 @@ contract Verifier {
     proof.C = Pairing.G1Point(c[0], c[1]);
 
     VerifyingKey memory vk = verifyingKey();
-    
+
     // Compute the linear combination vk_x of inputs times IC
     if (input.length + 1 != vk.IC.length) revert Pairing.InvalidProof();
     Pairing.G1Point memory vk_x = vk.IC[0];
@@ -234,14 +233,18 @@ contract Verifier {
     vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[2], input[1]));
     vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[3], input[2]));
     vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[4], input[3]));
- 
+
     // Check pairing
     Pairing.G1Point[] memory p1 = new Pairing.G1Point[](4);
     Pairing.G2Point[] memory p2 = new Pairing.G2Point[](4);
-    p1[0] = Pairing.negate(proof.A);  p2[0] = proof.B;
-    p1[1] = vk.alfa1;                 p2[1] = vk.beta2;
-    p1[2] = vk_x;                     p2[2] = vk.gamma2;
-    p1[3] = proof.C;                  p2[3] = vk.delta2;
+    p1[0] = Pairing.negate(proof.A);
+    p2[0] = proof.B;
+    p1[1] = vk.alfa1;
+    p2[1] = vk.beta2;
+    p1[2] = vk_x;
+    p2[2] = vk.gamma2;
+    p1[3] = proof.C;
+    p2[3] = vk.delta2;
     Pairing.pairingCheck(p1, p2);
   }
 }

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -217,12 +217,11 @@ contract Verifier {
     
     // Compute the linear combination vk_x of inputs times IC
     if (input.length + 1 != vk.IC.length) revert Pairing.InvalidProof();
-    Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+    Pairing.G1Point memory vk_x = vk.IC[0];
     for (uint256 i = 0; i < input.length; i++) {
       if (input[i] >= Pairing.SCALAR_MODULUS) revert Pairing.InvalidProof();
       vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
     }
-    vk_x = Pairing.addition(vk_x, vk.IC[0]);
  
     // Check pairing
     Pairing.G1Point[] memory p1 = new Pairing.G1Point[](4);

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -221,11 +221,12 @@ contract Verifier {
     
     // Compute the linear combination vk_x of inputs times IC
     if (input.length + 1 != vk.IC.length) revert Pairing.InvalidProof();
+    // By EIP196 the scalar_mul verifies its input is in the correct range.
     Pairing.G1Point memory vk_x = vk.IC[0];
-    for (uint256 i = 0; i < input.length; i++) {
-      // By EIP196 the scalar_mul verifies it's input is in the correct range.
-      vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
-    }
+    vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[1], input[0]));
+    vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[2], input[1]));
+    vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[3], input[2]));
+    vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[4], input[3]));
  
     // Check pairing
     Pairing.G1Point[] memory p1 = new Pairing.G1Point[](4);

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -262,7 +262,18 @@ contract Verifier {
     );
   }
 
-  function verify(uint256[4] memory input, Proof memory proof) internal view returns (bool) {
+  /// @return r  bool true if proof is valid
+  function verifyProof(
+    uint256[2] memory a,
+    uint256[2][2] memory b,
+    uint256[2] memory c,
+    uint256[4] memory input
+  ) public view returns (bool r) {
+    Proof memory proof;
+    proof.A = Pairing.G1Point(a[0], a[1]);
+    proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
+    proof.C = Pairing.G1Point(c[0], c[1]);
+
     uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
     VerifyingKey memory vk = verifyingKey();
     require(input.length + 1 == vk.IC.length, "verifier-bad-input");
@@ -275,19 +286,5 @@ contract Verifier {
     vk_x = Pairing.addition(vk_x, vk.IC[0]);
     bool pairingCheck = Pairing.pairingProd4(Pairing.negate(proof.A), proof.B, vk.alfa1, vk.beta2, vk_x, vk.gamma2, proof.C, vk.delta2);
     return pairingCheck;
-  }
-
-  /// @return r  bool true if proof is valid
-  function verifyProof(
-    uint256[2] memory a,
-    uint256[2][2] memory b,
-    uint256[2] memory c,
-    uint256[4] memory input
-  ) public view returns (bool r) {
-    Proof memory proof;
-    proof.A = Pairing.G1Point(a[0], a[1]);
-    proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
-    proof.C = Pairing.G1Point(c[0], c[1]);
-    return verify(input, proof);
   }
 }

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -199,15 +199,17 @@ contract Verifier {
     );
   }
 
-  /// @return r  bool true if proof is valid
+  /// @dev Verifies a Semaphore proof. Reverts with InvalidProof if the proof is invalid.
+  /// @return Returns `true` if the proof is valid, reversts otherwise.
   function verifyProof(
     uint256[2] memory a,
     uint256[2][2] memory b,
     uint256[2] memory c,
     uint256[4] memory input
-  ) public view returns (bool r) {
+  ) public view returns (bool) {
 
-    // If the values are not in the correct range, the pairing check will fail.
+    // If the values are not in the correct range, the pairing check will fail
+    // because by EIP197 it verfies all input.
     Proof memory proof;
     proof.A = Pairing.G1Point(a[0], a[1]);
     proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
@@ -219,7 +221,7 @@ contract Verifier {
     if (input.length + 1 != vk.IC.length) revert Pairing.InvalidProof();
     Pairing.G1Point memory vk_x = vk.IC[0];
     for (uint256 i = 0; i < input.length; i++) {
-      if (input[i] >= Pairing.SCALAR_MODULUS) revert Pairing.InvalidProof();
+      // By EIP196 the scalar_mul verifies it's input is in the correct range.
       vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
     }
  

--- a/contracts/base/Verifier.sol
+++ b/contracts/base/Verifier.sol
@@ -13,6 +13,7 @@
 //       cleaned up code
 //       added InvalidProve() error
 //       always revert with InvalidProof() on invalid proof
+//       make Pairing strict
 //      
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.4;
@@ -212,7 +213,6 @@ contract Verifier {
   }
 
   /// @dev Verifies a Semaphore proof. Reverts with InvalidProof if the proof is invalid.
-  /// @return Returns `true` if the proof is valid, reversts otherwise.
   function verifyProof(
     uint256[2] memory a,
     uint256[2][2] memory b,
@@ -243,7 +243,5 @@ contract Verifier {
     p1[2] = vk_x;                     p2[2] = vk.gamma2;
     p1[3] = proof.C;                  p2[3] = vk.delta2;
     Pairing.pairingCheck(p1, p2);
-
-    return true; // TODO: For backwards compatibility.
   }
 }

--- a/contracts/extensions/SemaphoreVoting.sol
+++ b/contracts/extensions/SemaphoreVoting.sol
@@ -88,11 +88,8 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     uint256 root = getRoot(pollId);
     IVerifier verifier = verifiers[depth];
 
-    require(
-      _isValidProof(vote, root, nullifierHash, pollId, proof, verifier),
-      "SemaphoreVoting: the proof is not valid"
-    );
-
+    _verifyProof(vote, root, nullifierHash, pollId, proof, verifier);
+    
     // Prevent double-voting (nullifierHash = hash(pollId + identityNullifier)).
     _saveNullifierHash(nullifierHash);
 

--- a/contracts/extensions/SemaphoreVoting.sol
+++ b/contracts/extensions/SemaphoreVoting.sol
@@ -89,7 +89,7 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     IVerifier verifier = verifiers[depth];
 
     _verifyProof(vote, root, nullifierHash, pollId, proof, verifier);
-    
+
     // Prevent double-voting (nullifierHash = hash(pollId + identityNullifier)).
     _saveNullifierHash(nullifierHash);
 

--- a/contracts/extensions/SemaphoreWhistleblowing.sol
+++ b/contracts/extensions/SemaphoreWhistleblowing.sol
@@ -81,10 +81,7 @@ contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreCore, Sem
     uint256 root = getRoot(entityId);
     IVerifier verifier = verifiers[depth];
 
-    require(
-      _isValidProof(leak, root, nullifierHash, entityId, proof, verifier),
-      "SemaphoreWhistleblowing: the proof is not valid"
-    );
+    _verifyProof(leak, root, nullifierHash, entityId, proof, verifier);
 
     emit LeakPublished(entityId, leak);
   }

--- a/contracts/interfaces/IVerifier.sol
+++ b/contracts/interfaces/IVerifier.sol
@@ -9,5 +9,5 @@ interface IVerifier {
     uint256[2][2] memory b,
     uint256[2] memory c,
     uint256[4] memory input
-  ) external view returns (bool);
+  ) external view;
 }

--- a/test/SemaphoreVoting.ts
+++ b/test/SemaphoreVoting.ts
@@ -163,7 +163,7 @@ describe("SemaphoreVoting", () => {
 
       const transaction = contract.connect(accounts[1]).castVote(bytes32Vote, nullifierHash, pollIds[1], solidityProof)
 
-      await expect(transaction).to.be.revertedWith("SemaphoreVoting: the proof is not valid")
+      await expect(transaction).to.be.revertedWith("InvalidProof()")
     })
 
     it("Should cast a vote", async () => {

--- a/test/SemaphoreWhistleblowing.ts
+++ b/test/SemaphoreWhistleblowing.ts
@@ -158,7 +158,7 @@ describe("SemaphoreWhistleblowing", () => {
         .connect(accounts[1])
         .publishLeak(bytes32Leak, nullifierHash, entityIds[1], solidityProof)
 
-      await expect(transaction).to.be.revertedWith("SemaphoreWhistleblowing: the proof is not valid")
+      await expect(transaction).to.be.revertedWith("InvalidProof()")
     })
 
     it("Should publish a leak", async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`yarn compile`) was run locally and any changes were pushed
- [ ] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently when provided with an invalid proof, the verifier will either:

* return `false`,
* execute the `invalid()` opcode,
* revert with one of a variety of error messages, like
  * `verifier-gte-snark-scalar-field`
  * `pairing-add-failed`,
  * etc..

This makes handling invalid proofs hard. Returning `false` is especially dangerous because it puts the burden on the caller.

## What is the new behavior?

When provided with an invalid proof, the verifier will:

* revert with `InvalidProof()`

In the unlikely event that the caller desires different behaviour, the caller can use a Solidity try/catch statement. 

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

The revert error message for an invalid proof changes.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
