### PR TITLE
Little Gas Optimization

### DIFF
--- a/contracts/Semaphore.sol
+++ b/contracts/Semaphore.sol
@@ -35,8 +35,10 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
     /// @dev Initializes the Semaphore verifiers used to verify the user's ZK proofs.
     /// @param _verifiers: List of Semaphore verifiers (address and related Merkle tree depth).
     constructor(Verifier[] memory _verifiers) {
-        for (uint8 i = 0; i < _verifiers.length; i++) {
-            verifiers[_verifiers[i].merkleTreeDepth] = IVerifier(_verifiers[i].contractAddress);
+        for (uint8 i = 0; i < _verifiers.length; ++i) {
+            verifiers[_verifiers[i].merkleTreeDepth] = IVerifier(
+                _verifiers[i].contractAddress
+            );
         }
     }
 
@@ -55,14 +57,22 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
     }
 
     /// @dev See {ISemaphore-updateGroupAdmin}.
-    function updateGroupAdmin(uint256 groupId, address newAdmin) external override onlyGroupAdmin(groupId) {
+    function updateGroupAdmin(uint256 groupId, address newAdmin)
+        external
+        override
+        onlyGroupAdmin(groupId)
+    {
         groupAdmins[groupId] = newAdmin;
 
         emit GroupAdminUpdated(groupId, _msgSender(), newAdmin);
     }
 
     /// @dev See {ISemaphore-addMember}.
-    function addMember(uint256 groupId, uint256 identityCommitment) external override onlyGroupAdmin(groupId) {
+    function addMember(uint256 groupId, uint256 identityCommitment)
+        external
+        override
+        onlyGroupAdmin(groupId)
+    {
         _addMember(groupId, identityCommitment);
     }
 
@@ -73,7 +83,12 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) external override onlyGroupAdmin(groupId) {
-        _removeMember(groupId, identityCommitment, proofSiblings, proofPathIndices);
+        _removeMember(
+            groupId,
+            identityCommitment,
+            proofSiblings,
+            proofPathIndices
+        );
     }
 
     /// @dev See {ISemaphore-verifyProof}.
@@ -93,7 +108,14 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
 
         IVerifier verifier = verifiers[depth];
 
-        _verifyProof(signal, root, nullifierHash, externalNullifier, proof, verifier);
+        _verifyProof(
+            signal,
+            root,
+            nullifierHash,
+            externalNullifier,
+            proof,
+            verifier
+        );
 
         _saveNullifierHash(nullifierHash);
 

--- a/contracts/Semaphore.sol
+++ b/contracts/Semaphore.sol
@@ -36,9 +36,7 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
     /// @param _verifiers: List of Semaphore verifiers (address and related Merkle tree depth).
     constructor(Verifier[] memory _verifiers) {
         for (uint8 i = 0; i < _verifiers.length; ++i) {
-            verifiers[_verifiers[i].merkleTreeDepth] = IVerifier(
-                _verifiers[i].contractAddress
-            );
+            verifiers[_verifiers[i].merkleTreeDepth] = IVerifier(_verifiers[i].contractAddress);
         }
     }
 
@@ -57,22 +55,14 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
     }
 
     /// @dev See {ISemaphore-updateGroupAdmin}.
-    function updateGroupAdmin(uint256 groupId, address newAdmin)
-        external
-        override
-        onlyGroupAdmin(groupId)
-    {
+    function updateGroupAdmin(uint256 groupId, address newAdmin) external override onlyGroupAdmin(groupId) {
         groupAdmins[groupId] = newAdmin;
 
         emit GroupAdminUpdated(groupId, _msgSender(), newAdmin);
     }
 
     /// @dev See {ISemaphore-addMember}.
-    function addMember(uint256 groupId, uint256 identityCommitment)
-        external
-        override
-        onlyGroupAdmin(groupId)
-    {
+    function addMember(uint256 groupId, uint256 identityCommitment) external override onlyGroupAdmin(groupId) {
         _addMember(groupId, identityCommitment);
     }
 
@@ -83,12 +73,7 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) external override onlyGroupAdmin(groupId) {
-        _removeMember(
-            groupId,
-            identityCommitment,
-            proofSiblings,
-            proofPathIndices
-        );
+        _removeMember(groupId, identityCommitment, proofSiblings, proofPathIndices);
     }
 
     /// @dev See {ISemaphore-verifyProof}.
@@ -108,14 +93,7 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
 
         IVerifier verifier = verifiers[depth];
 
-        _verifyProof(
-            signal,
-            root,
-            nullifierHash,
-            externalNullifier,
-            proof,
-            verifier
-        );
+        _verifyProof(signal, root, nullifierHash, externalNullifier, proof, verifier);
 
         _saveNullifierHash(nullifierHash);
 

--- a/contracts/extensions/SemaphoreVoting.sol
+++ b/contracts/extensions/SemaphoreVoting.sol
@@ -26,7 +26,7 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
             "SemaphoreVoting: parameters lists does not have the same length"
         );
 
-        for (uint8 i = 0; i < depths.length; i++) {
+        for (uint8 i = 0; i < depths.length; ++i) {
             verifiers[depths[i]] = IVerifier(verifierAddresses[i]);
         }
     }
@@ -34,7 +34,10 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     /// @dev Checks if the poll coordinator is the transaction sender.
     /// @param pollId: Id of the poll.
     modifier onlyCoordinator(uint256 pollId) {
-        require(polls[pollId].coordinator == _msgSender(), "SemaphoreVoting: caller is not the poll coordinator");
+        require(
+            polls[pollId].coordinator == _msgSender(),
+            "SemaphoreVoting: caller is not the poll coordinator"
+        );
         _;
     }
 
@@ -44,7 +47,10 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
         address coordinator,
         uint8 depth
     ) public override {
-        require(address(verifiers[depth]) != address(0), "SemaphoreVoting: depth value is not supported");
+        require(
+            address(verifiers[depth]) != address(0),
+            "SemaphoreVoting: depth value is not supported"
+        );
 
         _createGroup(pollId, depth, 0);
 
@@ -58,15 +64,29 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     }
 
     /// @dev See {ISemaphoreVoting-addVoter}.
-    function addVoter(uint256 pollId, uint256 identityCommitment) public override onlyCoordinator(pollId) {
-        require(polls[pollId].state == PollState.Created, "SemaphoreVoting: voters can only be added before voting");
+    function addVoter(uint256 pollId, uint256 identityCommitment)
+        public
+        override
+        onlyCoordinator(pollId)
+    {
+        require(
+            polls[pollId].state == PollState.Created,
+            "SemaphoreVoting: voters can only be added before voting"
+        );
 
         _addMember(pollId, identityCommitment);
     }
 
     /// @dev See {ISemaphoreVoting-addVoter}.
-    function startPoll(uint256 pollId, uint256 encryptionKey) public override onlyCoordinator(pollId) {
-        require(polls[pollId].state == PollState.Created, "SemaphoreVoting: poll has already been started");
+    function startPoll(uint256 pollId, uint256 encryptionKey)
+        public
+        override
+        onlyCoordinator(pollId)
+    {
+        require(
+            polls[pollId].state == PollState.Created,
+            "SemaphoreVoting: poll has already been started"
+        );
 
         polls[pollId].state = PollState.Ongoing;
 
@@ -82,7 +102,10 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     ) public override onlyCoordinator(pollId) {
         Poll memory poll = polls[pollId];
 
-        require(poll.state == PollState.Ongoing, "SemaphoreVoting: vote can only be cast in an ongoing poll");
+        require(
+            poll.state == PollState.Ongoing,
+            "SemaphoreVoting: vote can only be cast in an ongoing poll"
+        );
 
         uint8 depth = getDepth(pollId);
         uint256 root = getRoot(pollId);
@@ -97,8 +120,15 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     }
 
     /// @dev See {ISemaphoreVoting-publishDecryptionKey}.
-    function endPoll(uint256 pollId, uint256 decryptionKey) public override onlyCoordinator(pollId) {
-        require(polls[pollId].state == PollState.Ongoing, "SemaphoreVoting: poll is not ongoing");
+    function endPoll(uint256 pollId, uint256 decryptionKey)
+        public
+        override
+        onlyCoordinator(pollId)
+    {
+        require(
+            polls[pollId].state == PollState.Ongoing,
+            "SemaphoreVoting: poll is not ongoing"
+        );
 
         polls[pollId].state = PollState.Ended;
 

--- a/contracts/extensions/SemaphoreVoting.sol
+++ b/contracts/extensions/SemaphoreVoting.sol
@@ -34,10 +34,7 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     /// @dev Checks if the poll coordinator is the transaction sender.
     /// @param pollId: Id of the poll.
     modifier onlyCoordinator(uint256 pollId) {
-        require(
-            polls[pollId].coordinator == _msgSender(),
-            "SemaphoreVoting: caller is not the poll coordinator"
-        );
+        require(polls[pollId].coordinator == _msgSender(), "SemaphoreVoting: caller is not the poll coordinator");
         _;
     }
 
@@ -47,10 +44,7 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
         address coordinator,
         uint8 depth
     ) public override {
-        require(
-            address(verifiers[depth]) != address(0),
-            "SemaphoreVoting: depth value is not supported"
-        );
+        require(address(verifiers[depth]) != address(0), "SemaphoreVoting: depth value is not supported");
 
         _createGroup(pollId, depth, 0);
 
@@ -64,29 +58,15 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     }
 
     /// @dev See {ISemaphoreVoting-addVoter}.
-    function addVoter(uint256 pollId, uint256 identityCommitment)
-        public
-        override
-        onlyCoordinator(pollId)
-    {
-        require(
-            polls[pollId].state == PollState.Created,
-            "SemaphoreVoting: voters can only be added before voting"
-        );
+    function addVoter(uint256 pollId, uint256 identityCommitment) public override onlyCoordinator(pollId) {
+        require(polls[pollId].state == PollState.Created, "SemaphoreVoting: voters can only be added before voting");
 
         _addMember(pollId, identityCommitment);
     }
 
     /// @dev See {ISemaphoreVoting-addVoter}.
-    function startPoll(uint256 pollId, uint256 encryptionKey)
-        public
-        override
-        onlyCoordinator(pollId)
-    {
-        require(
-            polls[pollId].state == PollState.Created,
-            "SemaphoreVoting: poll has already been started"
-        );
+    function startPoll(uint256 pollId, uint256 encryptionKey) public override onlyCoordinator(pollId) {
+        require(polls[pollId].state == PollState.Created, "SemaphoreVoting: poll has already been started");
 
         polls[pollId].state = PollState.Ongoing;
 
@@ -102,10 +82,7 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     ) public override onlyCoordinator(pollId) {
         Poll memory poll = polls[pollId];
 
-        require(
-            poll.state == PollState.Ongoing,
-            "SemaphoreVoting: vote can only be cast in an ongoing poll"
-        );
+        require(poll.state == PollState.Ongoing, "SemaphoreVoting: vote can only be cast in an ongoing poll");
 
         uint8 depth = getDepth(pollId);
         uint256 root = getRoot(pollId);
@@ -120,15 +97,8 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
     }
 
     /// @dev See {ISemaphoreVoting-publishDecryptionKey}.
-    function endPoll(uint256 pollId, uint256 decryptionKey)
-        public
-        override
-        onlyCoordinator(pollId)
-    {
-        require(
-            polls[pollId].state == PollState.Ongoing,
-            "SemaphoreVoting: poll is not ongoing"
-        );
+    function endPoll(uint256 pollId, uint256 decryptionKey) public override onlyCoordinator(pollId) {
+        require(polls[pollId].state == PollState.Ongoing, "SemaphoreVoting: poll is not ongoing");
 
         polls[pollId].state = PollState.Ended;
 

--- a/contracts/extensions/SemaphoreWhistleblowing.sol
+++ b/contracts/extensions/SemaphoreWhistleblowing.sol
@@ -9,7 +9,11 @@ import "../base/SemaphoreGroups.sol";
 /// @dev The following code allows you to create entities for whistleblowers (e.g. non-profit
 /// organization, newspaper) and to allow them to publish news leaks anonymously.
 /// Leaks can be IPFS hashes, permanent links or other kinds of reference.
-contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreCore, SemaphoreGroups {
+contract SemaphoreWhistleblowing is
+    ISemaphoreWhistleblowing,
+    SemaphoreCore,
+    SemaphoreGroups
+{
     /// @dev Gets a tree depth and returns its verifier address.
     mapping(uint8 => IVerifier) internal verifiers;
 
@@ -28,7 +32,7 @@ contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreCore, Sem
             "SemaphoreWhistleblowing: parameters lists does not have the same length"
         );
 
-        for (uint8 i = 0; i < depths.length; i++) {
+        for (uint8 i = 0; i < depths.length; ++i) {
             verifiers[depths[i]] = IVerifier(verifierAddresses[i]);
         }
     }
@@ -36,7 +40,10 @@ contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreCore, Sem
     /// @dev Checks if the editor is the transaction sender.
     /// @param entityId: Id of the entity.
     modifier onlyEditor(uint256 entityId) {
-        require(entityId == entities[_msgSender()], "SemaphoreWhistleblowing: caller is not the editor");
+        require(
+            entityId == entities[_msgSender()],
+            "SemaphoreWhistleblowing: caller is not the editor"
+        );
         _;
     }
 
@@ -46,7 +53,10 @@ contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreCore, Sem
         address editor,
         uint8 depth
     ) public override {
-        require(address(verifiers[depth]) != address(0), "SemaphoreWhistleblowing: depth value is not supported");
+        require(
+            address(verifiers[depth]) != address(0),
+            "SemaphoreWhistleblowing: depth value is not supported"
+        );
 
         _createGroup(entityId, depth, 0);
 
@@ -56,7 +66,11 @@ contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreCore, Sem
     }
 
     /// @dev See {ISemaphoreWhistleblowing-addWhistleblower}.
-    function addWhistleblower(uint256 entityId, uint256 identityCommitment) public override onlyEditor(entityId) {
+    function addWhistleblower(uint256 entityId, uint256 identityCommitment)
+        public
+        override
+        onlyEditor(entityId)
+    {
         _addMember(entityId, identityCommitment);
     }
 
@@ -67,7 +81,12 @@ contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreCore, Sem
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) public override onlyEditor(entityId) {
-        _removeMember(entityId, identityCommitment, proofSiblings, proofPathIndices);
+        _removeMember(
+            entityId,
+            identityCommitment,
+            proofSiblings,
+            proofPathIndices
+        );
     }
 
     /// @dev See {ISemaphoreWhistleblowing-publishLeak}.

--- a/contracts/extensions/SemaphoreWhistleblowing.sol
+++ b/contracts/extensions/SemaphoreWhistleblowing.sol
@@ -9,11 +9,7 @@ import "../base/SemaphoreGroups.sol";
 /// @dev The following code allows you to create entities for whistleblowers (e.g. non-profit
 /// organization, newspaper) and to allow them to publish news leaks anonymously.
 /// Leaks can be IPFS hashes, permanent links or other kinds of reference.
-contract SemaphoreWhistleblowing is
-    ISemaphoreWhistleblowing,
-    SemaphoreCore,
-    SemaphoreGroups
-{
+contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreCore, SemaphoreGroups {
     /// @dev Gets a tree depth and returns its verifier address.
     mapping(uint8 => IVerifier) internal verifiers;
 
@@ -40,10 +36,7 @@ contract SemaphoreWhistleblowing is
     /// @dev Checks if the editor is the transaction sender.
     /// @param entityId: Id of the entity.
     modifier onlyEditor(uint256 entityId) {
-        require(
-            entityId == entities[_msgSender()],
-            "SemaphoreWhistleblowing: caller is not the editor"
-        );
+        require(entityId == entities[_msgSender()], "SemaphoreWhistleblowing: caller is not the editor");
         _;
     }
 
@@ -53,10 +46,7 @@ contract SemaphoreWhistleblowing is
         address editor,
         uint8 depth
     ) public override {
-        require(
-            address(verifiers[depth]) != address(0),
-            "SemaphoreWhistleblowing: depth value is not supported"
-        );
+        require(address(verifiers[depth]) != address(0), "SemaphoreWhistleblowing: depth value is not supported");
 
         _createGroup(entityId, depth, 0);
 
@@ -66,11 +56,7 @@ contract SemaphoreWhistleblowing is
     }
 
     /// @dev See {ISemaphoreWhistleblowing-addWhistleblower}.
-    function addWhistleblower(uint256 entityId, uint256 identityCommitment)
-        public
-        override
-        onlyEditor(entityId)
-    {
+    function addWhistleblower(uint256 entityId, uint256 identityCommitment) public override onlyEditor(entityId) {
         _addMember(entityId, identityCommitment);
     }
 
@@ -81,12 +67,7 @@ contract SemaphoreWhistleblowing is
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) public override onlyEditor(entityId) {
-        _removeMember(
-            entityId,
-            identityCommitment,
-            proofSiblings,
-            proofPathIndices
-        );
+        _removeMember(entityId, identityCommitment, proofSiblings, proofPathIndices);
     }
 
     /// @dev See {ISemaphoreWhistleblowing-publishLeak}.


### PR DESCRIPTION

## Description

`++i` costs a little less gas than `i++`
As `i++` returns the non-incremented value & `++i` returns the incremented value.

## Related Issue

N/A

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Other information

For More info check this: https://ethereum.stackexchange.com/questions/133161/why-does-i-cost-less-gas-than-i

And here are the gas snapshots,
Before:
![semaphoreBefore](https://user-images.githubusercontent.com/99166851/184510980-f3403a60-8430-47a1-9988-700652ea306e.JPG)
After:
![semaphoreAfter](https://user-images.githubusercontent.com/99166851/184510987-7002b883-fcac-4383-beaf-fe5b94360650.JPG)


Thanks,
AB Dee

P.S. I only changed 3 lines of code, other additions and deletions are just prettier's thing xD
