### PR TITLE
Feat/group nullifier hashes

### DIFF
--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -170,6 +170,6 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
 
         _saveNullifierHash(uint256(keccak256(abi.encodePacked(groupId, nullifierHash))));
 
-        emit ProofVerified(groupId, signal);
+        emit ProofVerified(groupId, merkleTreeRoot, nullifierHash, externalNullifier, signal);
     }
 }

--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -168,7 +168,7 @@ contract Semaphore is ISemaphore, SemaphoreCore, SemaphoreGroups {
 
         _verifyProof(signal, merkleTreeRoot, nullifierHash, externalNullifier, proof, verifier);
 
-        _saveNullifierHash(nullifierHash);
+        _saveNullifierHash(uint256(keccak256(abi.encodePacked(groupId, nullifierHash))));
 
         emit ProofVerified(groupId, signal);
     }

--- a/packages/contracts/contracts/interfaces/ISemaphore.sol
+++ b/packages/contracts/contracts/interfaces/ISemaphore.sol
@@ -29,8 +29,17 @@ interface ISemaphore {
 
     /// @dev Emitted when a Semaphore proof is verified.
     /// @param groupId: Id of the group.
+    /// @param merkleTreeRoot: Root of the Merkle tree.
+    /// @param externalNullifier: External nullifier.
+    /// @param nullifierHash: Nullifier hash.
     /// @param signal: Semaphore signal.
-    event ProofVerified(uint256 indexed groupId, bytes32 signal);
+    event ProofVerified(
+        uint256 indexed groupId,
+        uint256 merkleTreeRoot,
+        uint256 externalNullifier,
+        uint256 nullifierHash,
+        bytes32 signal
+    );
 
     /// @dev Saves the nullifier hash to avoid double signaling and emits an event
     /// if the zero-knowledge proof is valid.

--- a/packages/contracts/test/Semaphore.ts
+++ b/packages/contracts/test/Semaphore.ts
@@ -241,7 +241,15 @@ describe("Semaphore", () => {
                 solidityProof
             )
 
-            await expect(transaction).to.emit(contract, "ProofVerified").withArgs(groupId, signal)
+            await expect(transaction)
+                .to.emit(contract, "ProofVerified")
+                .withArgs(
+                    groupId,
+                    group.root,
+                    fullProof.publicSignals.nullifierHash,
+                    fullProof.publicSignals.externalNullifier,
+                    signal
+                )
         })
 
         it("Should not verify a proof if the Merkle tree root is expired", async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR hashes the nullifier hash with the group id, so that it can be specific to that group. It also adds the proof parameters to the `ProofVerified` event.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#135 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
