### PR TITLE
Custom nullifier hashes

### DIFF
--- a/packages/contracts/contracts/base/SemaphoreCore.sol
+++ b/packages/contracts/contracts/base/SemaphoreCore.sol
@@ -10,10 +10,6 @@ import "../interfaces/IVerifier.sol";
 /// nullifier to prevent double-signaling. External nullifier and Merkle trees (i.e. groups) must be
 /// managed externally.
 contract SemaphoreCore is ISemaphoreCore {
-    /// @dev Gets a nullifier hash and returns true or false.
-    /// It is used to prevent double-signaling.
-    mapping(uint256 => bool) internal nullifierHashes;
-
     /// @dev Asserts that no nullifier already exists and if the zero-knowledge proof is valid.
     /// Otherwise it reverts.
     /// @param signal: Semaphore signal.
@@ -30,10 +26,6 @@ contract SemaphoreCore is ISemaphoreCore {
         uint256[8] calldata proof,
         IVerifier verifier
     ) internal view {
-        if (nullifierHashes[nullifierHash]) {
-            revert Semaphore__YouAreUsingTheSameNillifierTwice();
-        }
-
         uint256 signalHash = _hashSignal(signal);
 
         verifier.verifyProof(
@@ -42,14 +34,6 @@ contract SemaphoreCore is ISemaphoreCore {
             [proof[6], proof[7]],
             [root, nullifierHash, signalHash, externalNullifier]
         );
-    }
-
-    /// @dev Stores the nullifier hash to prevent double-signaling.
-    /// Attention! Remember to call it when you verify a proof if you
-    /// need to prevent double-signaling.
-    /// @param nullifierHash: Semaphore nullifier hash.
-    function _saveNullifierHash(uint256 nullifierHash) internal {
-        nullifierHashes[nullifierHash] = true;
     }
 
     /// @dev Creates a keccak256 hash of the signal.

--- a/packages/contracts/contracts/base/SemaphoreGroups.sol
+++ b/packages/contracts/contracts/base/SemaphoreGroups.sol
@@ -12,8 +12,8 @@ import "@openzeppelin/contracts/utils/Context.sol";
 abstract contract SemaphoreGroups is Context, ISemaphoreGroups {
     using IncrementalBinaryTree for IncrementalTreeData;
 
-    /// @dev Gets a group id and returns the group/tree data.
-    mapping(uint256 => IncrementalTreeData) internal groups;
+    /// @dev Gets a group id and returns the tree data.
+    mapping(uint256 => IncrementalTreeData) internal merkleTree;
 
     /// @dev Creates a new group by initializing the associated tree.
     /// @param groupId: Id of the group.
@@ -32,7 +32,7 @@ abstract contract SemaphoreGroups is Context, ISemaphoreGroups {
             revert Semaphore__GroupAlreadyExists();
         }
 
-        groups[groupId].init(merkleTreeDepth, zeroValue);
+        merkleTree[groupId].init(merkleTreeDepth, zeroValue);
 
         emit GroupCreated(groupId, merkleTreeDepth, zeroValue);
     }
@@ -45,7 +45,7 @@ abstract contract SemaphoreGroups is Context, ISemaphoreGroups {
             revert Semaphore__GroupDoesNotExist();
         }
 
-        groups[groupId].insert(identityCommitment);
+        merkleTree[groupId].insert(identityCommitment);
 
         uint256 merkleTreeRoot = getMerkleTreeRoot(groupId);
         uint256 index = getNumberOfMerkleTreeLeaves(groupId) - 1;
@@ -71,7 +71,7 @@ abstract contract SemaphoreGroups is Context, ISemaphoreGroups {
             revert Semaphore__GroupDoesNotExist();
         }
 
-        groups[groupId].update(identityCommitment, newIdentityCommitment, proofSiblings, proofPathIndices);
+        merkleTree[groupId].update(identityCommitment, newIdentityCommitment, proofSiblings, proofPathIndices);
 
         uint256 merkleTreeRoot = getMerkleTreeRoot(groupId);
         uint256 index = proofPathIndicesToMemberIndex(proofPathIndices);
@@ -95,7 +95,7 @@ abstract contract SemaphoreGroups is Context, ISemaphoreGroups {
             revert Semaphore__GroupDoesNotExist();
         }
 
-        groups[groupId].remove(identityCommitment, proofSiblings, proofPathIndices);
+        merkleTree[groupId].remove(identityCommitment, proofSiblings, proofPathIndices);
 
         uint256 merkleTreeRoot = getMerkleTreeRoot(groupId);
         uint256 index = proofPathIndicesToMemberIndex(proofPathIndices);
@@ -105,17 +105,17 @@ abstract contract SemaphoreGroups is Context, ISemaphoreGroups {
 
     /// @dev See {ISemaphoreGroups-getMerkleTreeRoot}.
     function getMerkleTreeRoot(uint256 groupId) public view virtual override returns (uint256) {
-        return groups[groupId].root;
+        return merkleTree[groupId].root;
     }
 
     /// @dev See {ISemaphoreGroups-getMerkleTreeDepth}.
     function getMerkleTreeDepth(uint256 groupId) public view virtual override returns (uint256) {
-        return groups[groupId].depth;
+        return merkleTree[groupId].depth;
     }
 
     /// @dev See {ISemaphoreGroups-getNumberOfMerkleTreeLeaves}.
     function getNumberOfMerkleTreeLeaves(uint256 groupId) public view virtual override returns (uint256) {
-        return groups[groupId].numberOfLeaves;
+        return merkleTree[groupId].numberOfLeaves;
     }
 
     /// @dev Converts the path indices of a Merkle proof to the identity commitment index in the tree.

--- a/packages/contracts/contracts/interfaces/ISemaphore.sol
+++ b/packages/contracts/contracts/interfaces/ISemaphore.sol
@@ -8,17 +8,19 @@ interface ISemaphore {
     error Semaphore__MerkleTreeDepthIsNotSupported();
     error Semaphore__MerkleTreeRootIsExpired();
     error Semaphore__MerkleTreeRootIsNotPartOfTheGroup();
+    error Semaphore__YouAreUsingTheSameNillifierTwice();
 
     struct Verifier {
         address contractAddress;
         uint256 merkleTreeDepth;
     }
 
-    /// It defines all the parameters needed to check whether a
-    /// zero-knowledge proof generated with a certain Merkle tree is still valid.
-    struct MerkleTreeExpiry {
-        uint256 rootDuration;
-        mapping(uint256 => uint256) rootCreationDates;
+    /// It defines all the group parameters, in addition to those in the Merkle tree.
+    struct Group {
+        address admin;
+        uint256 merkleRootDuration;
+        mapping(uint256 => uint256) merkleRootCreationDates;
+        mapping(uint256 => bool) nullifierHashes;
     }
 
     /// @dev Emitted when an admin is assigned to a group.

--- a/packages/contracts/contracts/interfaces/ISemaphoreCore.sol
+++ b/packages/contracts/contracts/interfaces/ISemaphoreCore.sol
@@ -4,8 +4,6 @@ pragma solidity 0.8.4;
 /// @title SemaphoreCore interface.
 /// @dev Interface of SemaphoreCore contract.
 interface ISemaphoreCore {
-    error Semaphore__YouAreUsingTheSameNillifierTwice();
-
     /// @notice Emitted when a proof is verified correctly and a new nullifier hash is added.
     /// @param nullifierHash: Hash of external and identity nullifiers.
     event NullifierHashAdded(uint256 nullifierHash);

--- a/packages/contracts/contracts/interfaces/ISemaphoreVoting.sol
+++ b/packages/contracts/contracts/interfaces/ISemaphoreVoting.sol
@@ -8,6 +8,7 @@ interface ISemaphoreVoting {
     error Semaphore__MerkleTreeDepthIsNotSupported();
     error Semaphore__PollHasAlreadyBeenStarted();
     error Semaphore__PollIsNotOngoing();
+    error Semaphore__YouAreUsingTheSameNillifierTwice();
 
     enum PollState {
         Created,

--- a/packages/contracts/test/Semaphore.ts
+++ b/packages/contracts/test/Semaphore.ts
@@ -252,6 +252,19 @@ describe("Semaphore", () => {
                 )
         })
 
+        it("Should not verify the same proof for an onchain group twice", async () => {
+            const transaction = contract.verifyProof(
+                groupId,
+                group.root,
+                signal,
+                fullProof.publicSignals.nullifierHash,
+                fullProof.publicSignals.merkleRoot,
+                solidityProof
+            )
+
+            await expect(transaction).to.be.revertedWith("Semaphore__YouAreUsingTheSameNillifierTwice()")
+        })
+
         it("Should not verify a proof if the Merkle tree root is expired", async () => {
             const groupId = 2
             const group = new Group(treeDepth)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

The way on-chain hash nullifiers are saved can change depending on the use case. 

This PR moves the nullifier hashes from the `SemaphoreCore.sol` contract to the outside. The `Semaphore.sol` contract now contains a custom mechanism for saving the nullifier hashes of each group and uses the same `Groups` structure for all parameters used by groups.

This PR also fixes a bug in the `Semaphore.sol` contract, where the `nullifierHash` to be checked was not the correct one.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#137 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->