### PR TITLE
Semaphore Hardhat plugin

### DIFF
--- a/packages/hardhat/README.md
+++ b/packages/hardhat/README.md
@@ -1,0 +1,115 @@
+<p align="center">
+    <h1 align="center">
+        Semaphore Hardhat plugin
+    </h1>
+    <p align="center">A Semaphore Hardhat plugin to deploy verifiers and Semaphore contracts.</p>
+</p>
+
+<p align="center">
+    <a href="https://github.com/semaphore-protocol">
+        <img src="https://img.shields.io/badge/project-Semaphore-blue.svg?style=flat-square">
+    </a>
+    <a href="https://github.com/semaphore-protocol/semaphore/blob/main/LICENSE">
+        <img alt="Github license" src="https://img.shields.io/github/license/semaphore-protocol/semaphore.svg?style=flat-square">
+    </a>
+    <a href="https://www.npmjs.com/package/@semaphore-protocol/hardhat">
+        <img alt="NPM version" src="https://img.shields.io/npm/v/@semaphore-protocol/hardhat?style=flat-square" />
+    </a>
+    <a href="https://npmjs.org/package/@semaphore-protocol/hardhat">
+        <img alt="Downloads" src="https://img.shields.io/npm/dm/@semaphore-protocol/hardhat.svg?style=flat-square" />
+    </a>
+    <a href="https://eslint.org/">
+        <img alt="Linter eslint" src="https://img.shields.io/badge/linter-eslint-8080f2?style=flat-square&logo=eslint" />
+    </a>
+    <a href="https://prettier.io/">
+        <img alt="Code style prettier" src="https://img.shields.io/badge/code%20style-prettier-f8bc45?style=flat-square&logo=prettier" />
+    </a>
+</p>
+
+<div align="center">
+    <h4>
+        <a href="https://github.com/semaphore-protocol/semaphore/blob/main/CONTRIBUTING.md">
+            👥 Contributing
+        </a>
+        <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+        <a href="https://github.com/semaphore-protocol/semaphore/blob/main/CODE_OF_CONDUCT.md">
+            🤝 Code of conduct
+        </a>
+        <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+        <a href="https://github.com/semaphore-protocol/semaphore/contribute">
+            🔎 Issues
+        </a>
+        <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+        <a href="https://discord.gg/6mSdGHnstH">
+            🗣️ Chat &amp; Support
+        </a>
+    </h4>
+</div>
+
+| This Hardhat plugin provides two simple tasks that can be used to deploy verifiers and Semaphore contracts without any additional configuration. |
+| ------------------------------------------------------------------------------------------------------------------------------------------------ |
+
+## 🛠 Install
+
+### npm or yarn
+
+Install the `@semaphore-protocol/hardhat` package with npm:
+
+```bash
+npm i @semaphore-protocol/hardhat
+```
+
+or yarn:
+
+```bash
+yarn add @semaphore-protocol/hardhat
+```
+
+## 📜 Usage
+
+Import the plugin in your `hardhat.config.ts` file:
+
+```typescript
+import "@semaphore-protocol/hardhat"
+import "./tasks/deploy"
+
+const hardhatConfig: HardhatUserConfig = {
+    solidity: "0.8.4"
+}
+
+export default hardhatConfig
+```
+
+And use its tasks to create your own `deploy` task and deploy your contract with a Semaphore address.
+
+```typescript
+import { task, types } from "hardhat/config"
+
+task("deploy", "Deploy a Greeter contract")
+    .addOptionalParam("logs", "Print the logs", true, types.boolean)
+    .setAction(async ({ logs }, { ethers, run }) => {
+        const { address: verifierAddress } = await run("deploy:verifier", { logs, merkleTreeDepth: 20 })
+
+        const { address: semaphoreAddress } = await run("deploy:semaphore", {
+            logs,
+            verifiers: [
+                {
+                    merkleTreeDepth: 20,
+                    contractAddress: verifierAddress
+                }
+            ]
+        })
+
+        const Greeter = await ethers.getContractFactory("Greeter")
+
+        const greeter = await Greeter.deploy(semaphoreAddress)
+
+        await greeter.deployed()
+
+        if (logs) {
+            console.log(`Greeter contract has been deployed to: ${greeter.address}`)
+        }
+
+        return greeter
+    })
+```

--- a/packages/hardhat/build.tsconfig.json
+++ b/packages/hardhat/build.tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "declarationDir": "dist/types"
+    },
+    "include": ["src"]
+}

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -1,0 +1,46 @@
+{
+    "name": "@semaphore-protocol/hardhat",
+    "version": "0.1.0",
+    "description": "A Semaphore Hardhat plugin to deploy verifiers and Semaphore contract.",
+    "license": "MIT",
+    "main": "dist/index.node.js",
+    "exports": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.node.js"
+    },
+    "types": "dist/types/index.d.ts",
+    "files": [
+        "dist/",
+        "src/",
+        "LICENSE",
+        "README.md"
+    ],
+    "repository": "https://github.com/semaphore-protocol/semaphore",
+    "homepage": "https://github.com/semaphore-protocol/semaphore/tree/main/packages/hardhat",
+    "bugs": {
+        "url": "https://github.com/semaphore-protocol/semaphore.git/issues"
+    },
+    "scripts": {
+        "build:watch": "rollup -c rollup.config.ts -w --configPlugin typescript",
+        "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin typescript",
+        "prepublishOnly": "yarn build"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "devDependencies": {
+        "hardhat": "^2.0.0",
+        "rollup-plugin-cleanup": "^3.2.1",
+        "rollup-plugin-typescript2": "^0.31.2"
+    },
+    "peerDependencies": {
+        "hardhat": "^2.0.0"
+    },
+    "dependencies": {
+        "@nomiclabs/hardhat-ethers": "^2.1.1",
+        "@semaphore-protocol/contracts": "^2.5.0",
+        "circomlibjs": "^0.0.8",
+        "ethers": "^5.7.1",
+        "hardhat-dependency-compiler": "^1.1.3"
+    }
+}

--- a/packages/hardhat/rollup.config.ts
+++ b/packages/hardhat/rollup.config.ts
@@ -1,0 +1,29 @@
+import typescript from "rollup-plugin-typescript2"
+import * as fs from "fs"
+import cleanup from "rollup-plugin-cleanup"
+
+const pkg = JSON.parse(fs.readFileSync("./package.json", "utf-8"))
+const banner = `/**
+ * @module ${pkg.name}
+ * @version ${pkg.version}
+ * @file ${pkg.description}
+ * @copyright Ethereum Foundation 2022
+ * @license ${pkg.license}
+ * @see [Github]{@link ${pkg.homepage}}
+*/`
+
+export default {
+    input: "src/index.ts",
+    output: [
+        { file: pkg.exports.require, format: "cjs", banner, exports: "auto" },
+        { file: pkg.exports.import, format: "es", banner }
+    ],
+    external: Object.keys(pkg.dependencies),
+    plugins: [
+        typescript({
+            tsconfig: "./build.tsconfig.json",
+            useTsconfigDeclarationDir: true
+        }),
+        cleanup({ comments: "jsdoc" })
+    ]
+}

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -1,0 +1,34 @@
+import { extendConfig } from "hardhat/config"
+import { HardhatConfig, HardhatUserConfig } from "hardhat/types"
+
+import "hardhat-dependency-compiler"
+import "@nomiclabs/hardhat-ethers"
+import "./tasks/deploy-semaphore"
+import "./tasks/deploy-verifier"
+
+extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
+    config.dependencyCompiler.paths = [
+        "@semaphore-protocol/contracts/verifiers/Verifier16.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier17.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier18.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier19.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier20.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier21.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier22.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier23.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier24.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier25.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier26.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier27.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier28.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier29.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier30.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier31.sol",
+        "@semaphore-protocol/contracts/verifiers/Verifier32.sol",
+        "@semaphore-protocol/contracts/Semaphore.sol"
+    ]
+
+    if (userConfig.dependencyCompiler?.paths) {
+        config.dependencyCompiler.paths = [...config.dependencyCompiler.paths, ...userConfig.dependencyCompiler.paths]
+    }
+})

--- a/packages/hardhat/src/tasks/deploy-semaphore.ts
+++ b/packages/hardhat/src/tasks/deploy-semaphore.ts
@@ -1,0 +1,51 @@
+import { poseidon_gencontract as poseidonContract } from "circomlibjs"
+import { Contract } from "ethers"
+import { task, types } from "hardhat/config"
+
+task("deploy:semaphore", "Deploy a Semaphore contract")
+    .addParam("verifiers", "Tree depths and verifier addresses", [], types.json)
+    .addOptionalParam<boolean>("logs", "Print the logs", true, types.boolean)
+    .setAction(async ({ logs, verifiers }, { ethers }): Promise<Contract> => {
+        const poseidonABI = poseidonContract.generateABI(2)
+        const poseidonBytecode = poseidonContract.createCode(2)
+
+        const [signer] = await ethers.getSigners()
+
+        const PoseidonLibFactory = new ethers.ContractFactory(poseidonABI, poseidonBytecode, signer)
+        const poseidonLib = await PoseidonLibFactory.deploy()
+
+        await poseidonLib.deployed()
+
+        if (logs) {
+            console.info(`Poseidon library has been deployed to: ${poseidonLib.address}`)
+        }
+
+        const IncrementalBinaryTreeLibFactory = await ethers.getContractFactory("IncrementalBinaryTree", {
+            libraries: {
+                PoseidonT3: poseidonLib.address
+            }
+        })
+        const incrementalBinaryTreeLib = await IncrementalBinaryTreeLibFactory.deploy()
+
+        await incrementalBinaryTreeLib.deployed()
+
+        if (logs) {
+            console.info(`IncrementalBinaryTree library has been deployed to: ${incrementalBinaryTreeLib.address}`)
+        }
+
+        const SemaphoreContractFactory = await ethers.getContractFactory("Semaphore", {
+            libraries: {
+                IncrementalBinaryTree: incrementalBinaryTreeLib.address
+            }
+        })
+
+        const semaphoreContract = await SemaphoreContractFactory.deploy(verifiers)
+
+        await semaphoreContract.deployed()
+
+        if (logs) {
+            console.info(`Semaphore contract has been deployed to: ${semaphoreContract.address}`)
+        }
+
+        return semaphoreContract
+    })

--- a/packages/hardhat/src/tasks/deploy-verifier.ts
+++ b/packages/hardhat/src/tasks/deploy-verifier.ts
@@ -1,0 +1,19 @@
+import { Contract } from "ethers"
+import { task, types } from "hardhat/config"
+
+task("deploy:verifier", "Deploy a Verifier contract")
+    .addParam<number>("merkleTreeDepth", "Merkle tree depth", undefined, types.int)
+    .addOptionalParam<boolean>("logs", "Print the logs", true, types.boolean)
+    .setAction(async ({ merkleTreeDepth, logs }, { ethers }): Promise<Contract> => {
+        const VerifierContractFactory = await ethers.getContractFactory(`Verifier${merkleTreeDepth}`)
+
+        const verifierContract = await VerifierContractFactory.deploy()
+
+        await verifierContract.deployed()
+
+        if (logs) {
+            console.info(`Verifier${merkleTreeDepth} contract has been deployed to: ${verifierContract.address}`)
+        }
+
+        return verifierContract
+    })

--- a/packages/hardhat/tsconfig.json
+++ b/packages/hardhat/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["src", "rollup.config.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,7 +2784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomiclabs/hardhat-ethers@npm:^2.0.6":
+"@nomiclabs/hardhat-ethers@npm:^2.0.6, @nomiclabs/hardhat-ethers@npm:^2.1.1":
   version: 2.1.1
   resolution: "@nomiclabs/hardhat-ethers@npm:2.1.1"
   peerDependencies:
@@ -2969,6 +2969,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@semaphore-protocol/contracts@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "@semaphore-protocol/contracts@npm:2.5.0"
+  dependencies:
+    "@openzeppelin/contracts": 4.4.2
+    "@zk-kit/incremental-merkle-tree.sol": 1.3.0
+  checksum: e42338749f886f74e207d544787e139e44ff5ccac70ca3a8f529d7ed6e9cbfe50c7dfb9cc0d35394d87fa012c91679fd98ab9b3611cac12fbfc72400b5efc424
+  languageName: node
+  linkType: hard
+
 "@semaphore-protocol/group@workspace:packages/group":
   version: 0.0.0-use.local
   resolution: "@semaphore-protocol/group@workspace:packages/group"
@@ -2978,6 +2988,23 @@ __metadata:
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2
     typedoc: ^0.22.11
+  languageName: unknown
+  linkType: soft
+
+"@semaphore-protocol/hardhat@workspace:packages/hardhat":
+  version: 0.0.0-use.local
+  resolution: "@semaphore-protocol/hardhat@workspace:packages/hardhat"
+  dependencies:
+    "@nomiclabs/hardhat-ethers": ^2.1.1
+    "@semaphore-protocol/contracts": ^2.5.0
+    circomlibjs: ^0.0.8
+    ethers: ^5.7.1
+    hardhat: ^2.0.0
+    hardhat-dependency-compiler: ^1.1.3
+    rollup-plugin-cleanup: ^3.2.1
+    rollup-plugin-typescript2: ^0.31.2
+  peerDependencies:
+    hardhat: ^2.0.0
   languageName: unknown
   linkType: soft
 
@@ -9090,7 +9117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^5.0.1, ethers@npm:^5.0.2, ethers@npm:^5.5.2, ethers@npm:^5.6.8":
+"ethers@npm:^5.0.1, ethers@npm:^5.0.2, ethers@npm:^5.5.2, ethers@npm:^5.6.8, ethers@npm:^5.7.1":
   version: 5.7.1
   resolution: "ethers@npm:5.7.1"
   dependencies:
@@ -10692,6 +10719,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hardhat-dependency-compiler@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "hardhat-dependency-compiler@npm:1.1.3"
+  peerDependencies:
+    hardhat: ^2.0.0
+  checksum: f32bd10ef259f5b316d0dbb1ab20257e0f59780d7e374d3f71efb0c550666a400575f7acfd755cc3e9ad1adcf8a1dc72cb52f7a9d984d15f4d8f6e6d1b2e480f
+  languageName: node
+  linkType: hard
+
 "hardhat-gas-reporter@npm:^1.0.8":
   version: 1.0.9
   resolution: "hardhat-gas-reporter@npm:1.0.9"
@@ -10705,7 +10741,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat@npm:^2.9.7":
+"hardhat@npm:^2.0.0, hardhat@npm:^2.9.7":
   version: 2.11.2
   resolution: "hardhat@npm:2.11.2"
   dependencies:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the `@semaphore-protocol/hardhat` package, which is a plugin that allows devs to use two simple tasks to deploy the Semaphore verifiers and the `Semaphore.sol` contract.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#139 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
