### PR TITLE
New identity class getters

### DIFF
--- a/packages/contracts/test/SemaphoreVoting.ts
+++ b/packages/contracts/test/SemaphoreVoting.ts
@@ -93,35 +93,32 @@ describe("SemaphoreVoting", () => {
         })
 
         it("Should not add a voter if the caller is not the coordinator", async () => {
-            const identity = new Identity()
-            const identityCommitment = identity.generateCommitment()
+            const { commitment } = new Identity()
 
-            const transaction = contract.addVoter(pollIds[0], identityCommitment)
+            const transaction = contract.addVoter(pollIds[0], commitment)
 
             await expect(transaction).to.be.revertedWith("Semaphore__CallerIsNotThePollCoordinator()")
         })
 
         it("Should not add a voter if the poll has already been started", async () => {
-            const identity = new Identity()
-            const identityCommitment = identity.generateCommitment()
+            const { commitment } = new Identity()
 
-            const transaction = contract.connect(accounts[1]).addVoter(pollIds[0], identityCommitment)
+            const transaction = contract.connect(accounts[1]).addVoter(pollIds[0], commitment)
 
             await expect(transaction).to.be.revertedWith("Semaphore__PollHasAlreadyBeenStarted()")
         })
 
         it("Should add a voter to an existing poll", async () => {
-            const identity = new Identity("test")
-            const identityCommitment = identity.generateCommitment()
+            const { commitment } = new Identity("test")
 
-            const transaction = contract.connect(accounts[1]).addVoter(pollIds[1], identityCommitment)
+            const transaction = contract.connect(accounts[1]).addVoter(pollIds[1], commitment)
 
             await expect(transaction)
                 .to.emit(contract, "MemberAdded")
                 .withArgs(
                     pollIds[1],
                     0,
-                    identityCommitment,
+                    commitment,
                     "14787813191318312920980352979830075893203307366494541177071234930769373297362"
                 )
         })
@@ -135,13 +132,12 @@ describe("SemaphoreVoting", () => {
 
     describe("# castVote", () => {
         const identity = new Identity("test")
-        const identityCommitment = identity.generateCommitment()
         const vote = "1"
         const bytes32Vote = utils.formatBytes32String(vote)
 
         const group = new Group(treeDepth)
 
-        group.addMembers([identityCommitment, BigInt(1)])
+        group.addMembers([identity.commitment, BigInt(1)])
 
         let solidityProof: SolidityProof
         let publicSignals: PublicSignals

--- a/packages/contracts/test/utils.ts
+++ b/packages/contracts/test/utils.ts
@@ -5,10 +5,9 @@ export function createIdentityCommitments(n: number): bigint[] {
     const identityCommitments: bigint[] = []
 
     for (let i = 0; i < n; i += 1) {
-        const identity = new Identity(i.toString())
-        const identityCommitment = identity.generateCommitment()
+        const { commitment } = new Identity(i.toString())
 
-        identityCommitments.push(identityCommitment)
+        identityCommitments.push(commitment)
     }
 
     return identityCommitments

--- a/packages/identity/src/identity.test.ts
+++ b/packages/identity/src/identity.test.ts
@@ -17,16 +17,17 @@ describe("Identity", () => {
             const identity1 = new Identity()
             const identity2 = new Identity()
 
-            expect(identity1.getTrapdoor()).not.toBe(identity2.getTrapdoor())
-            expect(identity1.getNullifier()).not.toBe(identity2.getNullifier())
+            expect(identity1.trapdoor).not.toBe(identity2.getTrapdoor())
+            expect(identity1.nullifier).not.toBe(identity2.getNullifier())
+            expect(identity1.commitment).not.toBe(identity2.getCommitment())
         })
 
         it("Should create deterministic identities from a message", () => {
             const identity1 = new Identity("message")
             const identity2 = new Identity("message")
 
-            expect(identity1.getTrapdoor()).toBe(identity2.getTrapdoor())
-            expect(identity1.getNullifier()).toBe(identity2.getNullifier())
+            expect(identity1.trapdoor).toBe(identity2.getTrapdoor())
+            expect(identity1.nullifier).toBe(identity2.getNullifier())
         })
 
         it("Should create deterministic identities from number/boolean messages", () => {
@@ -35,10 +36,10 @@ describe("Identity", () => {
             const identity3 = new Identity("7")
             const identity4 = new Identity("7")
 
-            expect(identity1.getTrapdoor()).toBe(identity2.getTrapdoor())
-            expect(identity1.getNullifier()).toBe(identity2.getNullifier())
-            expect(identity3.getTrapdoor()).toBe(identity4.getTrapdoor())
-            expect(identity3.getNullifier()).toBe(identity4.getNullifier())
+            expect(identity1.trapdoor).toBe(identity2.getTrapdoor())
+            expect(identity1.nullifier).toBe(identity2.getNullifier())
+            expect(identity3.trapdoor).toBe(identity4.getTrapdoor())
+            expect(identity3.nullifier).toBe(identity4.getNullifier())
         })
 
         it("Should not recreate an existing invalid identity", () => {
@@ -52,8 +53,8 @@ describe("Identity", () => {
 
             const identity2 = new Identity(identity1.toString())
 
-            expect(identity1.getTrapdoor()).toBe(identity2.getTrapdoor())
-            expect(identity1.getNullifier()).toBe(identity2.getNullifier())
+            expect(identity1.trapdoor).toBe(identity2.getTrapdoor())
+            expect(identity1.nullifier).toBe(identity2.getNullifier())
         })
     })
 

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -1,11 +1,12 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { poseidon } from "circomlibjs"
 import checkParameter from "./checkParameter"
-import { genRandomNumber, isJsonArray, sha256 } from "./utils"
+import { generateCommitment, genRandomNumber, isJsonArray, sha256 } from "./utils"
 
 export default class Identity {
     private _trapdoor: bigint
     private _nullifier: bigint
+    private _commitment: bigint
 
     /**
      * Initializes the class attributes based on the strategy passed as parameter.
@@ -15,6 +16,7 @@ export default class Identity {
         if (identityOrMessage === undefined) {
             this._trapdoor = genRandomNumber()
             this._nullifier = genRandomNumber()
+            this._commitment = generateCommitment(this._nullifier, this._trapdoor)
 
             return
         }
@@ -26,6 +28,7 @@ export default class Identity {
 
             this._trapdoor = BigNumber.from(sha256(`${messageHash}identity_trapdoor`)).toBigInt()
             this._nullifier = BigNumber.from(sha256(`${messageHash}identity_nullifier`)).toBigInt()
+            this._commitment = generateCommitment(this._nullifier, this._trapdoor)
 
             return
         }
@@ -34,6 +37,15 @@ export default class Identity {
 
         this._trapdoor = BigNumber.from(`0x${trapdoor}`).toBigInt()
         this._nullifier = BigNumber.from(`0x${nullifier}`).toBigInt()
+        this._commitment = generateCommitment(this._nullifier, this._trapdoor)
+    }
+
+    /**
+     * Returns the identity trapdoor.
+     * @returns The identity trapdoor.
+     */
+    public get trapdoor(): bigint {
+        return this._trapdoor
     }
 
     /**
@@ -48,11 +60,36 @@ export default class Identity {
      * Returns the identity nullifier.
      * @returns The identity nullifier.
      */
+    public get nullifier(): bigint {
+        return this._nullifier
+    }
+
+    /**
+     * Returns the identity nullifier.
+     * @returns The identity nullifier.
+     */
     public getNullifier(): bigint {
         return this._nullifier
     }
 
     /**
+     * Returns the identity commitment.
+     * @returns The identity commitment.
+     */
+    public get commitment(): bigint {
+        return this._commitment
+    }
+
+    /**
+     * Returns the identity commitment.
+     * @returns The identity commitment.
+     */
+    public getCommitment(): bigint {
+        return this._commitment
+    }
+
+    /**
+     * @deprecated since version 2.6.0
      * Generates the identity commitment from trapdoor and nullifier.
      * @returns identity commitment
      */

--- a/packages/identity/src/utils.ts
+++ b/packages/identity/src/utils.ts
@@ -2,6 +2,7 @@ import { BigNumber } from "@ethersproject/bignumber"
 import { randomBytes } from "@ethersproject/random"
 import { sha256 as _sha256 } from "@ethersproject/sha2"
 import { toUtf8Bytes } from "@ethersproject/strings"
+import { poseidon } from "circomlibjs"
 
 /**
  * Returns an hexadecimal sha256 hash of the message passed as parameter.
@@ -21,6 +22,16 @@ export function sha256(message: string): string {
  */
 export function genRandomNumber(numberOfBytes = 31): bigint {
     return BigNumber.from(randomBytes(numberOfBytes)).toBigInt()
+}
+
+/**
+ * Generates the identity commitment from trapdoor and nullifier.
+ * @param nullifier The identity nullifier.
+ * @param trapdoor The identity trapdoor.
+ * @returns identity commitment
+ */
+export function generateCommitment(nullifier: bigint, trapdoor: bigint): bigint {
+    return poseidon([poseidon([nullifier, trapdoor])])
 }
 
 /**

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -36,8 +36,8 @@
         "typedoc": "^0.22.11"
     },
     "peerDependencies": {
-        "@semaphore-protocol/group": "2.4.0",
-        "@semaphore-protocol/identity": "2.4.0"
+        "@semaphore-protocol/group": "2.5.0",
+        "@semaphore-protocol/identity": "2.5.0"
     },
     "dependencies": {
         "@ethersproject/bytes": "^5.7.0",

--- a/packages/proof/src/generateProof.ts
+++ b/packages/proof/src/generateProof.ts
@@ -6,14 +6,12 @@ import generateSignalHash from "./generateSignalHash"
 import { BigNumberish, FullProof, SnarkArtifacts } from "./types"
 
 export default async function generateProof(
-    identity: Identity,
+    { trapdoor, nullifier, commitment }: Identity,
     groupOrMerkleProof: Group | MerkleProof,
     externalNullifier: BigNumberish,
     signal: string,
     snarkArtifacts?: SnarkArtifacts
 ): Promise<FullProof> {
-    const commitment = identity.generateCommitment()
-
     let merkleProof: MerkleProof
 
     if ("depth" in groupOrMerkleProof) {
@@ -37,8 +35,8 @@ export default async function generateProof(
 
     const { proof, publicSignals } = await groth16.fullProve(
         {
-            identityTrapdoor: identity.getTrapdoor(),
-            identityNullifier: identity.getNullifier(),
+            identityTrapdoor: trapdoor,
+            identityNullifier: nullifier,
             treePathIndices: merkleProof.pathIndices,
             treeSiblings: merkleProof.siblings,
             externalNullifier,

--- a/packages/proof/src/index.test.ts
+++ b/packages/proof/src/index.test.ts
@@ -21,7 +21,6 @@ describe("Proof", () => {
     const verificationKeyPath = `./snark-artifacts/semaphore.json`
 
     const identity = new Identity()
-    const identityCommitment = identity.generateCommitment()
 
     let fullProof: FullProof
     let curve: any
@@ -52,7 +51,7 @@ describe("Proof", () => {
         it("Should not generate a Semaphore proof with default snark artifacts with Node.js", async () => {
             const group = new Group(treeDepth)
 
-            group.addMembers([BigInt(1), BigInt(2), identityCommitment])
+            group.addMembers([BigInt(1), BigInt(2), identity.commitment])
 
             const fun = () => generateProof(identity, group, externalNullifier, signal)
 
@@ -62,7 +61,7 @@ describe("Proof", () => {
         it("Should generate a Semaphore proof passing a group as parameter", async () => {
             const group = new Group(treeDepth)
 
-            group.addMembers([BigInt(1), BigInt(2), identityCommitment])
+            group.addMembers([BigInt(1), BigInt(2), identity.commitment])
 
             fullProof = await generateProof(identity, group, externalNullifier, signal, {
                 wasmFilePath,
@@ -77,7 +76,7 @@ describe("Proof", () => {
         it("Should generate a Semaphore proof passing a Merkle proof as parametr", async () => {
             const group = new Group(treeDepth)
 
-            group.addMembers([BigInt(1), BigInt(2), identityCommitment])
+            group.addMembers([BigInt(1), BigInt(2), identity.commitment])
 
             fullProof = await generateProof(identity, group.generateProofOfMembership(2), externalNullifier, signal, {
                 wasmFilePath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,8 +3038,8 @@ __metadata:
     snarkjs: ^0.4.13
     typedoc: ^0.22.11
   peerDependencies:
-    "@semaphore-protocol/group": 2.4.0
-    "@semaphore-protocol/identity": 2.4.0
+    "@semaphore-protocol/group": 2.5.0
+    "@semaphore-protocol/identity": 2.5.0
   languageName: unknown
   linkType: soft
 
@@ -8861,7 +8861,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
+  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR add three getters to the `Identity` class: `trapdoor`, `nullifier`, `commitment`. The identity commitment is now generated in the class constructor. The `generateCommitment` method has been marked as deprecated, but it can still be used by devs.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #141 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
