### PR TITLE
Public `merkleTree` attribute and new method name

### DIFF
--- a/packages/contracts/test/Semaphore.ts
+++ b/packages/contracts/test/Semaphore.ts
@@ -146,7 +146,7 @@ describe("Semaphore", () => {
             await contract["createGroup(uint256,uint256,uint256,address)"](groupId, treeDepth, 0, accounts[0])
             await contract.addMembers(groupId, members)
 
-            const { siblings, pathIndices, root } = group.generateProofOfMembership(0)
+            const { siblings, pathIndices, root } = group.generateMerkleProof(0)
 
             const transaction = contract.updateMember(groupId, BigInt(1), BigInt(4), siblings, pathIndices)
 
@@ -177,7 +177,7 @@ describe("Semaphore", () => {
             await contract["createGroup(uint256,uint256,uint256,address)"](groupId, treeDepth, 0, accounts[0])
             await contract.addMembers(groupId, members)
 
-            const { siblings, pathIndices, root } = group.generateProofOfMembership(2)
+            const { siblings, pathIndices, root } = group.generateMerkleProof(2)
 
             const transaction = contract.removeMember(groupId, BigInt(3), siblings, pathIndices)
 

--- a/packages/contracts/test/SemaphoreWhistleblowing.ts
+++ b/packages/contracts/test/SemaphoreWhistleblowing.ts
@@ -103,7 +103,7 @@ describe("SemaphoreWhistleblowing", () => {
 
             group.addMember(commitment)
 
-            const { siblings, pathIndices } = group.generateProofOfMembership(0)
+            const { siblings, pathIndices } = group.generateMerkleProof(0)
 
             const transaction = contract.removeWhistleblower(entityIds[0], commitment, siblings, pathIndices)
 
@@ -116,7 +116,7 @@ describe("SemaphoreWhistleblowing", () => {
 
             group.addMember(commitment)
 
-            const { siblings, pathIndices } = group.generateProofOfMembership(0)
+            const { siblings, pathIndices } = group.generateMerkleProof(0)
 
             const transaction = contract
                 .connect(accounts[1])

--- a/packages/group/README.md
+++ b/packages/group/README.md
@@ -120,8 +120,8 @@ group.removeMember(0)
 group.indexOf(commitment) // 0
 ```
 
-\# **generateProofOfMembership**(index: _number_): _MerkleProof_
+\# **generateMerkleProof**(index: _number_): _MerkleProof_
 
 ```typescript
-const proof = group.generateProofOfMembership(0)
+const proof = group.generateMerkleProof(0)
 ```

--- a/packages/group/src/group.test.ts
+++ b/packages/group/src/group.test.ts
@@ -82,12 +82,12 @@ describe("Group", () => {
         })
     })
 
-    describe("# generateProofOfMembership", () => {
+    describe("# generateMerkleProof", () => {
         it("Should generate a proof of membership", () => {
             const group = new Group()
             group.addMembers([BigInt(1), BigInt(3)])
 
-            const proof = group.generateProofOfMembership(0)
+            const proof = group.generateMerkleProof(0)
 
             expect(proof.leaf).toBe(BigInt(1))
         })

--- a/packages/group/src/group.ts
+++ b/packages/group/src/group.ts
@@ -3,7 +3,7 @@ import { poseidon } from "circomlibjs"
 import { Member } from "./types"
 
 export default class Group {
-    private _merkleTree: IncrementalMerkleTree
+    merkleTree: IncrementalMerkleTree
 
     /**
      * Initializes the group with the tree depth and the zero value.
@@ -15,7 +15,7 @@ export default class Group {
             throw new Error("The tree depth must be between 16 and 32")
         }
 
-        this._merkleTree = new IncrementalMerkleTree(poseidon, treeDepth, zeroValue, 2)
+        this.merkleTree = new IncrementalMerkleTree(poseidon, treeDepth, zeroValue, 2)
     }
 
     /**
@@ -23,7 +23,7 @@ export default class Group {
      * @returns Root hash.
      */
     get root(): Member {
-        return this._merkleTree.root
+        return this.merkleTree.root
     }
 
     /**
@@ -31,7 +31,7 @@ export default class Group {
      * @returns Tree depth.
      */
     get depth(): number {
-        return this._merkleTree.depth
+        return this.merkleTree.depth
     }
 
     /**
@@ -39,7 +39,7 @@ export default class Group {
      * @returns Tree zero value.
      */
     get zeroValue(): Member {
-        return this._merkleTree.zeroes[0]
+        return this.merkleTree.zeroes[0]
     }
 
     /**
@@ -47,7 +47,7 @@ export default class Group {
      * @returns List of members.
      */
     get members(): Member[] {
-        return this._merkleTree.leaves
+        return this.merkleTree.leaves
     }
 
     /**
@@ -56,34 +56,34 @@ export default class Group {
      * @returns Index of the member.
      */
     indexOf(member: Member): number {
-        return this._merkleTree.indexOf(member)
+        return this.merkleTree.indexOf(member)
     }
 
     /**
      * Adds a new member to the group.
-     * @param identityCommitment New member.
+     * @param member New member.
      */
-    addMember(identityCommitment: Member) {
-        this._merkleTree.insert(BigInt(identityCommitment))
+    addMember(member: Member) {
+        this.merkleTree.insert(BigInt(member))
     }
 
     /**
      * Adds new members to the group.
-     * @param identityCommitments New members.
+     * @param members New members.
      */
-    addMembers(identityCommitments: Member[]) {
-        for (const identityCommitment of identityCommitments) {
-            this.addMember(identityCommitment)
+    addMembers(members: Member[]) {
+        for (const member of members) {
+            this.addMember(member)
         }
     }
 
     /**
      * Updates a member in the group.
      * @param index Index of the member to be updated.
-     * @param identityCommitment New member value.
+     * @param member New member value.
      */
-    updateMember(index: number, identityCommitment: Member) {
-        this._merkleTree.update(index, identityCommitment)
+    updateMember(index: number, member: Member) {
+        this.merkleTree.update(index, member)
     }
 
     /**
@@ -91,7 +91,7 @@ export default class Group {
      * @param index Index of the member to be removed.
      */
     removeMember(index: number) {
-        this._merkleTree.delete(index)
+        this.merkleTree.delete(index)
     }
 
     /**
@@ -99,8 +99,8 @@ export default class Group {
      * @param index Index of the proof's member.
      * @returns Proof object.
      */
-    generateProofOfMembership(index: number): MerkleProof {
-        const merkleProof = this._merkleTree.createProof(index)
+    generateMerkleProof(index: number): MerkleProof {
+        const merkleProof = this.merkleTree.createProof(index)
 
         merkleProof.siblings = merkleProof.siblings.map((s) => s[0])
 

--- a/packages/proof/src/generateProof.ts
+++ b/packages/proof/src/generateProof.ts
@@ -21,7 +21,7 @@ export default async function generateProof(
             throw new Error("The identity is not part of the group")
         }
 
-        merkleProof = groupOrMerkleProof.generateProofOfMembership(index)
+        merkleProof = groupOrMerkleProof.generateMerkleProof(index)
     } else {
         merkleProof = groupOrMerkleProof
     }

--- a/packages/proof/src/index.test.ts
+++ b/packages/proof/src/index.test.ts
@@ -78,7 +78,7 @@ describe("Proof", () => {
 
             group.addMembers([BigInt(1), BigInt(2), identity.commitment])
 
-            fullProof = await generateProof(identity, group.generateProofOfMembership(2), externalNullifier, signal, {
+            fullProof = await generateProof(identity, group.generateMerkleProof(2), externalNullifier, signal, {
                 wasmFilePath,
                 zkeyFilePath
             })


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR makes the `group.merkleTree` attribute public and updates the `generateProofOfMembership` name to `generateMerkleProof`. 

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #158

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
