### PR TITLE
Remove modifiers from proof verification functions

### DIFF
--- a/packages/contracts/contracts/extensions/SemaphoreVoting.sol
+++ b/packages/contracts/contracts/extensions/SemaphoreVoting.sol
@@ -87,7 +87,7 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreCore, SemaphoreGroups {
         uint256 nullifierHash,
         uint256 pollId,
         uint256[8] calldata proof
-    ) public override onlyCoordinator(pollId) {
+    ) public override {
         Poll memory poll = polls[pollId];
 
         if (poll.state != PollState.Ongoing) {

--- a/packages/contracts/contracts/extensions/SemaphoreWhistleblowing.sol
+++ b/packages/contracts/contracts/extensions/SemaphoreWhistleblowing.sol
@@ -76,7 +76,7 @@ contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreCore, Sem
         uint256 nullifierHash,
         uint256 entityId,
         uint256[8] calldata proof
-    ) public override onlyEditor(entityId) {
+    ) public override {
         uint256 merkleTreeDepth = getMerkleTreeDepth(entityId);
         uint256 merkleTreeRoot = getMerkleTreeRoot(entityId);
 

--- a/packages/contracts/test/SemaphoreVoting.ts
+++ b/packages/contracts/test/SemaphoreVoting.ts
@@ -156,12 +156,6 @@ describe("SemaphoreVoting", () => {
             solidityProof = packToSolidityProof(fullProof.proof)
         })
 
-        it("Should not cast a vote if the caller is not the coordinator", async () => {
-            const transaction = contract.castVote(bytes32Vote, publicSignals.nullifierHash, pollIds[0], solidityProof)
-
-            await expect(transaction).to.be.revertedWith("Semaphore__CallerIsNotThePollCoordinator()")
-        })
-
         it("Should not cast a vote if the poll is not ongoing", async () => {
             const transaction = contract
                 .connect(accounts[1])

--- a/packages/contracts/test/SemaphoreWhistleblowing.ts
+++ b/packages/contracts/test/SemaphoreWhistleblowing.ts
@@ -159,17 +159,6 @@ describe("SemaphoreWhistleblowing", () => {
             solidityProof = packToSolidityProof(fullProof.proof)
         })
 
-        it("Should not publish a leak if the caller is not the editor", async () => {
-            const transaction = contract.publishLeak(
-                bytes32Leak,
-                publicSignals.nullifierHash,
-                entityIds[0],
-                solidityProof
-            )
-
-            await expect(transaction).to.be.revertedWith("Semaphore__CallerIsNotTheEditor()")
-        })
-
         it("Should not publish a leak if the proof is not valid", async () => {
             const nullifierHash = generateNullifierHash(entityIds[0], identity.getNullifier())
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR removes the `onlyCoordinator` and `onlyEditor` modifiers from the extension contracts' functions to verify Semaphore proofs, which are actually unnecessary. Anyone can then call those functions.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #155

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
