### PR TITLE
New Poseidon library

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
         "@typescript-eslint/eslint-plugin": "^5.9.1",
         "@typescript-eslint/parser": "^5.9.1",
         "babel-jest": "^27.4.6",
-        "circomlibjs": "^0.0.8",
         "commitizen": "^4.2.4",
         "cz-conventional-changelog": "^3.3.0",
         "dotenv": "^16.0.2",

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -36,6 +36,6 @@
     },
     "dependencies": {
         "@zk-kit/incremental-merkle-tree": "1.0.0",
-        "circomlibjs": "0.0.8"
+        "poseidon-lite": "^0.0.2"
     }
 }

--- a/packages/group/src/group.ts
+++ b/packages/group/src/group.ts
@@ -1,5 +1,5 @@
 import { IncrementalMerkleTree, MerkleProof } from "@zk-kit/incremental-merkle-tree"
-import { poseidon } from "circomlibjs"
+import poseidon from "poseidon-lite"
 import { Member } from "./types"
 
 export default class Group {

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -39,6 +39,6 @@
         "@ethersproject/random": "^5.5.1",
         "@ethersproject/sha2": "^5.6.1",
         "@ethersproject/strings": "^5.6.1",
-        "circomlibjs": "0.0.8"
+        "poseidon-lite": "^0.0.2"
     }
 }

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "@ethersproject/bignumber"
-import { poseidon } from "circomlibjs"
+import poseidon from "poseidon-lite"
 import checkParameter from "./checkParameter"
 import { generateCommitment, genRandomNumber, isJsonArray, sha256 } from "./utils"
 

--- a/packages/identity/src/utils.ts
+++ b/packages/identity/src/utils.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "@ethersproject/bignumber"
 import { randomBytes } from "@ethersproject/random"
 import { sha256 as _sha256 } from "@ethersproject/sha2"
 import { toUtf8Bytes } from "@ethersproject/strings"
-import { poseidon } from "circomlibjs"
+import poseidon from "poseidon-lite"
 
 /**
  * Returns an hexadecimal sha256 hash of the message passed as parameter.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3021,7 +3021,7 @@ __metadata:
   resolution: "@semaphore-protocol/group@workspace:packages/group"
   dependencies:
     "@zk-kit/incremental-merkle-tree": 1.0.0
-    circomlibjs: 0.0.8
+    poseidon-lite: ^0.0.2
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2
     typedoc: ^0.22.11
@@ -3053,7 +3053,7 @@ __metadata:
     "@ethersproject/random": ^5.5.1
     "@ethersproject/sha2": ^5.6.1
     "@ethersproject/strings": ^5.6.1
-    circomlibjs: 0.0.8
+    poseidon-lite: ^0.0.2
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2
     typedoc: ^0.22.11
@@ -6498,7 +6498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"circomlibjs@npm:0.0.8, circomlibjs@npm:^0.0.8":
+"circomlibjs@npm:^0.0.8":
   version: 0.0.8
   resolution: "circomlibjs@npm:0.0.8"
   dependencies:
@@ -15568,6 +15568,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"poseidon-lite@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "poseidon-lite@npm:0.0.2"
+  checksum: b10a29ec8b84caa75dcbb323e7586f220ed5e2d338864484cbc735ee871aafcae599b1c98c521aebd9b82798d5d354328d7750d7dd4bd0c51f7f6d0b79cbe00e
+  languageName: node
+  linkType: hard
+
 "posix-character-classes@npm:^0.1.0":
   version: 0.1.1
   resolution: "posix-character-classes@npm:0.1.1"
@@ -16956,7 +16963,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.9.1
     "@typescript-eslint/parser": ^5.9.1
     babel-jest: ^27.4.6
-    circomlibjs: ^0.0.8
     commitizen: ^4.2.4
     cz-conventional-changelog: ^3.3.0
     dotenv: ^16.0.2


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR replaces the `circomlibjs` dependency with [`poseidon-lite`](https://github.com/vimwitch/poseidon-lite) in the following packages: `@semaphore-protocol/identity`, `@semaphore-protocol/group`.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #171 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
