### PR TITLE
New hash function to generate identity secrets

### DIFF
--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -36,8 +36,8 @@
     },
     "dependencies": {
         "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/keccak256": "^5.7.0",
         "@ethersproject/random": "^5.5.1",
-        "@ethersproject/sha2": "^5.6.1",
         "@ethersproject/strings": "^5.6.1",
         "poseidon-lite": "^0.0.2"
     }

--- a/packages/identity/src/hash.ts
+++ b/packages/identity/src/hash.ts
@@ -1,0 +1,11 @@
+import { keccak256 } from "@ethersproject/keccak256"
+import { toUtf8Bytes } from "@ethersproject/strings"
+
+/**
+ * Creates a keccak256 hash of a message compatible with the SNARK scalar modulus.
+ * @param message The message to be hashed.
+ * @returns The message digest.
+ */
+export default function hash(message: string): bigint {
+    return BigInt(keccak256(toUtf8Bytes(message))) >> BigInt(8)
+}

--- a/packages/identity/src/identity.test.ts
+++ b/packages/identity/src/identity.test.ts
@@ -64,9 +64,7 @@ describe("Identity", () => {
 
             const trapdoor = identity.getTrapdoor()
 
-            expect(trapdoor).toBe(
-                BigInt("58952291509798197436757858062402199043831251943841934828591473955215726495831")
-            )
+            expect(trapdoor).toBe(BigInt("211007102311354422986775462856672883657031335757695461477990303178796954863"))
         })
     })
 
@@ -76,20 +74,16 @@ describe("Identity", () => {
 
             const nullifier = identity.getNullifier()
 
-            expect(nullifier).toBe(
-                BigInt("44673097405870585416457571638073245190425597599743560105244308998175651589997")
-            )
+            expect(nullifier).toBe(BigInt("10282208199720122340759039255952223220417076359839127631923809108800013776"))
         })
     })
 
     describe("# generateCommitment", () => {
         it("Should generate an identity commitment", () => {
-            const identity = new Identity("message")
-
-            const commitment = identity.generateCommitment()
+            const { commitment } = new Identity("message")
 
             expect(commitment).toBe(
-                BigInt("1720349790382552497189398984241859233944354304766757200361065203741879866188")
+                BigInt("13192222509545780880434144549342414064490325100975031303723930089730328393905")
             )
         })
     })
@@ -108,8 +102,8 @@ describe("Identity", () => {
 
             const [trapdoor, nullifier] = JSON.parse(identity.toString())
 
-            expect(BigNumber.from(`0x${trapdoor}`).toBigInt()).toBe(identity.getTrapdoor())
-            expect(BigNumber.from(`0x${nullifier}`).toBigInt()).toBe(identity.getNullifier())
+            expect(BigNumber.from(`0x${trapdoor}`).toBigInt()).toBe(identity.trapdoor)
+            expect(BigNumber.from(`0x${nullifier}`).toBigInt()).toBe(identity.nullifier)
         })
     })
 })

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -1,7 +1,8 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import poseidon from "poseidon-lite"
 import checkParameter from "./checkParameter"
-import { generateCommitment, genRandomNumber, isJsonArray, sha256 } from "./utils"
+import hash from "./hash"
+import { generateCommitment, genRandomNumber, isJsonArray } from "./utils"
 
 export default class Identity {
     private _trapdoor: bigint
@@ -24,10 +25,10 @@ export default class Identity {
         checkParameter(identityOrMessage, "identityOrMessage", "string")
 
         if (!isJsonArray(identityOrMessage)) {
-            const messageHash = sha256(identityOrMessage).slice(2)
+            const messageHash = hash(identityOrMessage)
 
-            this._trapdoor = BigNumber.from(sha256(`${messageHash}identity_trapdoor`)).toBigInt()
-            this._nullifier = BigNumber.from(sha256(`${messageHash}identity_nullifier`)).toBigInt()
+            this._trapdoor = hash(`${messageHash}identity_trapdoor`)
+            this._nullifier = hash(`${messageHash}identity_nullifier`)
             this._commitment = generateCommitment(this._nullifier, this._trapdoor)
 
             return
@@ -86,15 +87,6 @@ export default class Identity {
      */
     public getCommitment(): bigint {
         return this._commitment
-    }
-
-    /**
-     * @deprecated since version 2.6.0
-     * Generates the identity commitment from trapdoor and nullifier.
-     * @returns identity commitment
-     */
-    public generateCommitment(): bigint {
-        return poseidon([poseidon([this._nullifier, this._trapdoor])])
     }
 
     /**

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -1,5 +1,4 @@
 import { BigNumber } from "@ethersproject/bignumber"
-import poseidon from "poseidon-lite"
 import checkParameter from "./checkParameter"
 import hash from "./hash"
 import { generateCommitment, genRandomNumber, isJsonArray } from "./utils"

--- a/packages/identity/src/utils.ts
+++ b/packages/identity/src/utils.ts
@@ -1,19 +1,6 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { randomBytes } from "@ethersproject/random"
-import { sha256 as _sha256 } from "@ethersproject/sha2"
-import { toUtf8Bytes } from "@ethersproject/strings"
 import poseidon from "poseidon-lite"
-
-/**
- * Returns an hexadecimal sha256 hash of the message passed as parameter.
- * @param message The string to hash.
- * @returns The hexadecimal hash of the message.
- */
-export function sha256(message: string): string {
-    const hash = _sha256(toUtf8Bytes(message))
-
-    return hash
-}
 
 /**
  * Generates a random big number.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,7 +2017,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/sha2@npm:5.7.0, @ethersproject/sha2@npm:^5.6.1, @ethersproject/sha2@npm:^5.7.0":
+"@ethersproject/sha2@npm:5.7.0, @ethersproject/sha2@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/sha2@npm:5.7.0"
   dependencies:
@@ -3341,8 +3341,8 @@ __metadata:
   resolution: "@semaphore-protocol/identity@workspace:packages/identity"
   dependencies:
     "@ethersproject/bignumber": ^5.5.0
+    "@ethersproject/keccak256": ^5.7.0
     "@ethersproject/random": ^5.5.1
-    "@ethersproject/sha2": ^5.6.1
     "@ethersproject/strings": ^5.6.1
     poseidon-lite: ^0.0.2
     rollup-plugin-cleanup: ^3.2.1


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR update the hash function to generate the identity secrets (`nullifier` and `trapdoor`), so as to keep their values within the SNARK scalar field. It also removes the deprecated `generateCommitment` function.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #190 

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
