### PR TITLE
Generate zeroValue based on groupId

### DIFF
--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -40,10 +40,9 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
     function createGroup(
         uint256 groupId,
         uint256 merkleTreeDepth,
-        uint256 zeroValue,
         address admin
     ) external override onlySupportedMerkleTreeDepth(merkleTreeDepth) {
-        _createGroup(groupId, merkleTreeDepth, zeroValue);
+        _createGroup(groupId, merkleTreeDepth);
 
         groups[groupId].admin = admin;
         groups[groupId].merkleRootDuration = 1 hours;
@@ -55,11 +54,10 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
     function createGroup(
         uint256 groupId,
         uint256 merkleTreeDepth,
-        uint256 zeroValue,
         address admin,
         uint256 merkleTreeRootDuration
     ) external override onlySupportedMerkleTreeDepth(merkleTreeDepth) {
-        _createGroup(groupId, merkleTreeDepth, zeroValue);
+        _createGroup(groupId, merkleTreeDepth);
 
         groups[groupId].admin = admin;
         groups[groupId].merkleRootDuration = merkleTreeRootDuration;

--- a/packages/contracts/contracts/base/SemaphoreGroups.sol
+++ b/packages/contracts/contracts/base/SemaphoreGroups.sol
@@ -17,15 +17,15 @@ abstract contract SemaphoreGroups is Context, ISemaphoreGroups {
     /// @dev Creates a new group by initializing the associated tree.
     /// @param groupId: Id of the group.
     /// @param merkleTreeDepth: Depth of the tree.
-    /// @param zeroValue: Zero value of the tree.
-    function _createGroup(
-        uint256 groupId,
-        uint256 merkleTreeDepth,
-        uint256 zeroValue
-    ) internal virtual {
+    function _createGroup(uint256 groupId, uint256 merkleTreeDepth) internal virtual {
         if (getMerkleTreeDepth(groupId) != 0) {
             revert Semaphore__GroupAlreadyExists();
         }
+
+        // The zeroValue is in fact an implicit member of the group.
+        // Although there is a remote possibility that the preimage of
+        // the hash may be calculated, using this value minimizes the risk.
+        uint256 zeroValue = uint256(keccak256(abi.encodePacked(groupId))) >> 8;
 
         merkleTree[groupId].init(merkleTreeDepth, zeroValue);
 

--- a/packages/contracts/contracts/extensions/SemaphoreVoting.sol
+++ b/packages/contracts/contracts/extensions/SemaphoreVoting.sol
@@ -43,7 +43,7 @@ contract SemaphoreVoting is ISemaphoreVoting, SemaphoreGroups {
             revert Semaphore__MerkleTreeDepthIsNotSupported();
         }
 
-        _createGroup(pollId, merkleTreeDepth, 0);
+        _createGroup(pollId, merkleTreeDepth);
 
         Poll memory poll;
 

--- a/packages/contracts/contracts/extensions/SemaphoreWhistleblowing.sol
+++ b/packages/contracts/contracts/extensions/SemaphoreWhistleblowing.sol
@@ -41,7 +41,7 @@ contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreGroups {
             revert Semaphore__MerkleTreeDepthIsNotSupported();
         }
 
-        _createGroup(entityId, merkleTreeDepth, 0);
+        _createGroup(entityId, merkleTreeDepth);
 
         entities[editor] = entityId;
 

--- a/packages/contracts/contracts/interfaces/ISemaphore.sol
+++ b/packages/contracts/contracts/interfaces/ISemaphore.sol
@@ -63,25 +63,21 @@ interface ISemaphore {
     /// @dev Creates a new group. Only the admin will be able to add or remove members.
     /// @param groupId: Id of the group.
     /// @param depth: Depth of the tree.
-    /// @param zeroValue: Zero value of the tree.
     /// @param admin: Admin of the group.
     function createGroup(
         uint256 groupId,
         uint256 depth,
-        uint256 zeroValue,
         address admin
     ) external;
 
     /// @dev Creates a new group. Only the admin will be able to add or remove members.
     /// @param groupId: Id of the group.
     /// @param depth: Depth of the tree.
-    /// @param zeroValue: Zero value of the tree.
     /// @param admin: Admin of the group.
     /// @param merkleTreeRootDuration: Time before the validity of a root expires.
     function createGroup(
         uint256 groupId,
         uint256 depth,
-        uint256 zeroValue,
         address admin,
         uint256 merkleTreeRootDuration
     ) external;

--- a/packages/contracts/test/Semaphore.ts
+++ b/packages/contracts/test/Semaphore.ts
@@ -50,7 +50,9 @@ describe("Semaphore", () => {
                 .connect(signers[1])
                 ["createGroup(uint256,uint256,address)"](groupId, treeDepth, accounts[1])
 
-            await expect(transaction).to.emit(semaphoreContract, "GroupCreated").withArgs(groupId, treeDepth, group.zeroValue)
+            await expect(transaction)
+                .to.emit(semaphoreContract, "GroupCreated")
+                .withArgs(groupId, treeDepth, group.zeroValue)
             await expect(transaction)
                 .to.emit(semaphoreContract, "GroupAdminUpdated")
                 .withArgs(groupId, constants.AddressZero, accounts[1])
@@ -59,17 +61,21 @@ describe("Semaphore", () => {
         it("Should create a group with a custom Merkle tree root expiration", async () => {
             const groupId = 2
             const group = new Group(2)
-            const transaction = await semaphoreContract.connect(signers[1])["createGroup(uint256,uint256,address,uint256)"](
-                groupId,
-                treeDepth,
-                accounts[0],
-                5 // 5 seconds.
-            )
-            await contract.addMember(groupId, members[0])
-            await contract.addMember(groupId, members[1])
-            await contract.addMember(groupId, members[2])
+            const transaction = await semaphoreContract
+                .connect(signers[1])
+                ["createGroup(uint256,uint256,address,uint256)"](
+                    groupId,
+                    treeDepth,
+                    accounts[0],
+                    5 // 5 seconds.
+                )
+            await semaphoreContract.addMember(groupId, members[0])
+            await semaphoreContract.addMember(groupId, members[1])
+            await semaphoreContract.addMember(groupId, members[2])
 
-            await expect(transaction).to.emit(semaphoreContract, "GroupCreated").withArgs(groupId, treeDepth, group.zeroValue)
+            await expect(transaction)
+                .to.emit(semaphoreContract, "GroupCreated")
+                .withArgs(groupId, treeDepth, group.zeroValue)
             await expect(transaction)
                 .to.emit(semaphoreContract, "GroupAdminUpdated")
                 .withArgs(groupId, constants.AddressZero, accounts[0])

--- a/packages/contracts/test/SemaphoreVoting.ts
+++ b/packages/contracts/test/SemaphoreVoting.ts
@@ -92,7 +92,7 @@ describe("SemaphoreVoting", () => {
 
         it("Should add a voter to an existing poll", async () => {
             const { commitment } = new Identity("test")
-            const group = new Group(treeDepth)
+            const group = new Group(pollIds[1], treeDepth)
 
             group.addMember(commitment)
 
@@ -112,7 +112,7 @@ describe("SemaphoreVoting", () => {
         const identity = new Identity("test")
         const vote = 1
 
-        const group = new Group(treeDepth)
+        const group = new Group(pollIds[1], treeDepth)
 
         group.addMembers([identity.commitment, BigInt(1)])
 

--- a/packages/contracts/test/SemaphoreWhistleblowing.ts
+++ b/packages/contracts/test/SemaphoreWhistleblowing.ts
@@ -58,7 +58,7 @@ describe("SemaphoreWhistleblowing", () => {
 
         it("Should add a whistleblower to an existing entity", async () => {
             const { commitment } = new Identity("test")
-            const group = new Group(treeDepth)
+            const group = new Group(entityIds[0], treeDepth)
 
             group.addMember(commitment)
 
@@ -77,7 +77,7 @@ describe("SemaphoreWhistleblowing", () => {
     describe("# removeWhistleblower", () => {
         it("Should not remove a whistleblower if the caller is not the editor", async () => {
             const { commitment } = new Identity()
-            const group = new Group(treeDepth)
+            const group = new Group(entityIds[0], treeDepth)
 
             group.addMember(commitment)
 
@@ -90,7 +90,7 @@ describe("SemaphoreWhistleblowing", () => {
 
         it("Should remove a whistleblower from an existing entity", async () => {
             const { commitment } = new Identity("test")
-            const group = new Group(treeDepth)
+            const group = new Group(entityIds[0], treeDepth)
 
             group.addMember(commitment)
 
@@ -112,7 +112,7 @@ describe("SemaphoreWhistleblowing", () => {
         const identity = new Identity("test")
         const leak = utils.formatBytes32String("This is a leak")
 
-        const group = new Group(treeDepth)
+        const group = new Group(entityIds[1], treeDepth)
 
         group.addMembers([identity.commitment, BigInt(1)])
 

--- a/packages/group/README.md
+++ b/packages/group/README.md
@@ -67,19 +67,19 @@ yarn add @semaphore-protocol/group
 
 ## 📜 Usage
 
-\# **new Group**(treeDepth = 20, zeroValue = BigInt(0)): _Group_
+\# **new Group**(groupId: _Member_, treeDepth = 20): _Group_
 
 ```typescript
 import { Group } from "@semaphore-protocol/group"
 
 // Group with max 1048576 members (20^²).
-const group1 = new Group()
+const group1 = new Group(1)
 
 // Group with max 65536 members (16^²).
-const group2 = new Group(16)
+const group2 = new Group(1, 16)
 
 // Group with max 16777216 members (24^²).
-const group3 = new Group(24)
+const group3 = new Group(1, 24)
 ```
 
 \# **addMember**(identityCommitment: _Member_)

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -35,6 +35,9 @@
         "typedoc": "^0.22.11"
     },
     "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
         "@zk-kit/incremental-merkle-tree": "1.0.0",
         "poseidon-lite": "^0.0.2"
     }

--- a/packages/group/src/group.test.ts
+++ b/packages/group/src/group.test.ts
@@ -1,35 +1,36 @@
 import Group from "./group"
+import hash from "./hash"
 
 describe("Group", () => {
     describe("# Group", () => {
         it("Should create a group", () => {
-            const group = new Group()
+            const group = new Group(1)
 
-            expect(group.root.toString()).toContain("150197")
+            expect(group.root.toString()).toContain("103543")
             expect(group.depth).toBe(20)
-            expect(group.zeroValue).toBe(BigInt(0))
+            expect(group.zeroValue).toBe(hash(1))
             expect(group.members).toHaveLength(0)
         })
 
         it("Should not create a group with a wrong tree depth", () => {
-            const fun = () => new Group(33)
+            const fun = () => new Group(1, 33)
 
             expect(fun).toThrow("The tree depth must be between 16 and 32")
         })
 
         it("Should create a group with different parameters", () => {
-            const group = new Group(32, BigInt(1))
+            const group = new Group(1, 32)
 
-            expect(group.root.toString()).toContain("640470")
+            expect(group.root.toString()).toContain("460373")
             expect(group.depth).toBe(32)
-            expect(group.zeroValue).toBe(BigInt(1))
+            expect(group.zeroValue).toBe(hash(1))
             expect(group.members).toHaveLength(0)
         })
     })
 
     describe("# addMember", () => {
         it("Should add a member to a group", () => {
-            const group = new Group()
+            const group = new Group(1)
 
             group.addMember(BigInt(3))
 
@@ -39,7 +40,7 @@ describe("Group", () => {
 
     describe("# addMembers", () => {
         it("Should add many members to a group", () => {
-            const group = new Group()
+            const group = new Group(1)
 
             group.addMembers([BigInt(1), BigInt(3)])
 
@@ -49,7 +50,7 @@ describe("Group", () => {
 
     describe("# indexOf", () => {
         it("Should return the index of a member in a group", () => {
-            const group = new Group()
+            const group = new Group(1)
             group.addMembers([BigInt(1), BigInt(3)])
 
             const index = group.indexOf(BigInt(3))
@@ -60,7 +61,7 @@ describe("Group", () => {
 
     describe("# updateMember", () => {
         it("Should update a member in a group", () => {
-            const group = new Group()
+            const group = new Group(1)
             group.addMembers([BigInt(1), BigInt(3)])
 
             group.updateMember(0, BigInt(1))
@@ -72,7 +73,7 @@ describe("Group", () => {
 
     describe("# removeMember", () => {
         it("Should remove a member from a group", () => {
-            const group = new Group()
+            const group = new Group(1)
             group.addMembers([BigInt(1), BigInt(3)])
 
             group.removeMember(0)
@@ -84,7 +85,7 @@ describe("Group", () => {
 
     describe("# generateMerkleProof", () => {
         it("Should generate a proof of membership", () => {
-            const group = new Group()
+            const group = new Group(1)
             group.addMembers([BigInt(1), BigInt(3)])
 
             const proof = group.generateMerkleProof(0)

--- a/packages/group/src/group.ts
+++ b/packages/group/src/group.ts
@@ -1,5 +1,6 @@
 import { IncrementalMerkleTree, MerkleProof } from "@zk-kit/incremental-merkle-tree"
 import poseidon from "poseidon-lite"
+import hash from "./hash"
 import { Member } from "./types"
 
 export default class Group {
@@ -7,15 +8,15 @@ export default class Group {
 
     /**
      * Initializes the group with the tree depth and the zero value.
+     * @param groupId Group identifier.
      * @param treeDepth Tree depth.
-     * @param zeroValue Zero values for zeroes.
      */
-    constructor(treeDepth = 20, zeroValue: Member = BigInt(0)) {
+    constructor(groupId: Member, treeDepth = 20) {
         if (treeDepth < 16 || treeDepth > 32) {
             throw new Error("The tree depth must be between 16 and 32")
         }
 
-        this.merkleTree = new IncrementalMerkleTree(poseidon, treeDepth, zeroValue, 2)
+        this.merkleTree = new IncrementalMerkleTree(poseidon, treeDepth, hash(groupId), 2)
     }
 
     /**

--- a/packages/group/src/hash.ts
+++ b/packages/group/src/hash.ts
@@ -1,0 +1,15 @@
+import { BigNumber } from "@ethersproject/bignumber"
+import { BytesLike, Hexable, zeroPad } from "@ethersproject/bytes"
+import { keccak256 } from "@ethersproject/keccak256"
+
+/**
+ * Creates a keccak256 hash of a message compatible with the SNARK scalar modulus.
+ * @param message The message to be hashed.
+ * @returns The message digest.
+ */
+export default function hash(message: BytesLike | Hexable | number | bigint): bigint {
+    message = BigNumber.from(message).toTwos(256).toHexString()
+    message = zeroPad(message, 32)
+
+    return BigInt(keccak256(message)) >> BigInt(8)
+}

--- a/packages/group/src/types/index.ts
+++ b/packages/group/src/types/index.ts
@@ -1,1 +1,1 @@
-export type Member = string | bigint
+export type Member = string | number | bigint

--- a/yarn.lock
+++ b/yarn.lock
@@ -3311,6 +3311,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@semaphore-protocol/group@workspace:packages/group"
   dependencies:
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/keccak256": ^5.7.0
     "@zk-kit/incremental-merkle-tree": 1.0.0
     poseidon-lite: ^0.0.2
     rollup-plugin-cleanup: ^3.2.1


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes the bug described in the issue #196 by generating a different `zeroValue` for each group based on the `groupId`. The `zeroValue` is basically the hash of the `groupId`.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #196

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This bug was found by [Veridise](https://veridise.com/) during their audit of Semaphore.