### PR TITLE
Editors can be associated with multiple entities

### DIFF
--- a/packages/contracts/contracts/extensions/SemaphoreWhistleblowing.sol
+++ b/packages/contracts/contracts/extensions/SemaphoreWhistleblowing.sol
@@ -12,13 +12,13 @@ import "../base/SemaphoreGroups.sol";
 contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreGroups {
     ISemaphoreVerifier public verifier;
 
-    /// @dev Gets an editor address and return their entity.
-    mapping(address => uint256) private entities;
+    /// @dev Gets an entity id and return its editor address.
+    mapping(uint256 => address) private entities;
 
     /// @dev Checks if the editor is the transaction sender.
     /// @param entityId: Id of the entity.
     modifier onlyEditor(uint256 entityId) {
-        if (entityId != entities[_msgSender()]) {
+        if (entities[entityId] != _msgSender()) {
             revert Semaphore__CallerIsNotTheEditor();
         }
 
@@ -43,7 +43,7 @@ contract SemaphoreWhistleblowing is ISemaphoreWhistleblowing, SemaphoreGroups {
 
         _createGroup(entityId, merkleTreeDepth, 0);
 
-        entities[editor] = entityId;
+        entities[entityId] = editor;
 
         emit EntityCreated(entityId, editor);
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR updates the `entities` mapping in the `SemaphoreWhistleblowing.sol` contract and allows an editor to be associated with multiple entities.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #198 

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This bug was found by Veridise during their audit of Semaphore.
