### PR TITLE
Increase size of iterator variable

### DIFF
--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -89,7 +89,7 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
         override
         onlyGroupAdmin(groupId)
     {
-        for (uint8 i = 0; i < identityCommitments.length; ) {
+        for (uint256 i = 0; i < identityCommitments.length; ) {
             _addMember(groupId, identityCommitments[i]);
 
             unchecked {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR increase the size of the iterator variable used to add members in a batch in the `addMembers` function.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #201 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This bug was found by [Veridise](https://veridise.com/) during their audit of Semaphore.
