### PR TITLE
Tree depth to check group existence

### DIFF
--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -140,11 +140,11 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
         uint256 externalNullifier,
         uint256[8] calldata proof
     ) external override {
-        uint256 currentMerkleTreeRoot = getMerkleTreeRoot(groupId);
-
-        if (currentMerkleTreeRoot == 0) {
+        if (getMerkleTreeDepth(groupId) == 0) {
             revert Semaphore__GroupDoesNotExist();
         }
+
+        uint256 currentMerkleTreeRoot = getMerkleTreeRoot(groupId);
 
         if (merkleTreeRoot != currentMerkleTreeRoot) {
             uint256 merkleRootCreationDate = groups[groupId].merkleRootCreationDates[merkleTreeRoot];

--- a/packages/contracts/contracts/base/SemaphoreGroups.sol
+++ b/packages/contracts/contracts/base/SemaphoreGroups.sol
@@ -62,7 +62,7 @@ abstract contract SemaphoreGroups is Context, ISemaphoreGroups {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal virtual {
-        if (getMerkleTreeRoot(groupId) == 0) {
+        if (getMerkleTreeDepth(groupId) == 0) {
             revert Semaphore__GroupDoesNotExist();
         }
 
@@ -86,7 +86,7 @@ abstract contract SemaphoreGroups is Context, ISemaphoreGroups {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal virtual {
-        if (getMerkleTreeRoot(groupId) == 0) {
+        if (getMerkleTreeDepth(groupId) == 0) {
             revert Semaphore__GroupDoesNotExist();
         }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR updates the group existence checks to use the depth of the tree rather than the tree root.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #202 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This bug was found by [Veridise](https://veridise.com/) during their audit of Semaphore.
