### PR TITLE
New function to update merkle tree duration

### DIFF
--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -46,7 +46,7 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
         _createGroup(groupId, merkleTreeDepth, zeroValue);
 
         groups[groupId].admin = admin;
-        groups[groupId].merkleRootDuration = 1 hours;
+        groups[groupId].merkleTreeDuration = 1 hours;
 
         emit GroupAdminUpdated(groupId, address(0), admin);
     }
@@ -57,12 +57,12 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
         uint256 merkleTreeDepth,
         uint256 zeroValue,
         address admin,
-        uint256 merkleTreeRootDuration
+        uint256 merkleTreeDuration
     ) external override onlySupportedMerkleTreeDepth(merkleTreeDepth) {
         _createGroup(groupId, merkleTreeDepth, zeroValue);
 
         groups[groupId].admin = admin;
-        groups[groupId].merkleRootDuration = merkleTreeRootDuration;
+        groups[groupId].merkleTreeDuration = merkleTreeDuration;
 
         emit GroupAdminUpdated(groupId, address(0), admin);
     }
@@ -72,6 +72,15 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
         groups[groupId].admin = newAdmin;
 
         emit GroupAdminUpdated(groupId, _msgSender(), newAdmin);
+    }
+
+    /// @dev See {ISemaphore-updateGroupMerkleTreeDuration}.
+    function updateGroupMerkleTreeDuration(uint256 groupId, uint256 newMerkleTreeDuration) external override onlyGroupAdmin(groupId) {
+        uint256 oldMerkleTreeDuration = groups[groupId].merkleTreeDuration;
+
+        groups[groupId].merkleTreeDuration = newMerkleTreeDuration;
+
+        emit GroupMerkleTreeDurationUpdated(groupId, oldMerkleTreeDuration, newMerkleTreeDuration);
     }
 
     /// @dev See {ISemaphore-addMember}.
@@ -148,13 +157,13 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
 
         if (merkleTreeRoot != currentMerkleTreeRoot) {
             uint256 merkleRootCreationDate = groups[groupId].merkleRootCreationDates[merkleTreeRoot];
-            uint256 merkleRootDuration = groups[groupId].merkleRootDuration;
+            uint256 merkleTreeDuration = groups[groupId].merkleTreeDuration;
 
             if (merkleRootCreationDate == 0) {
                 revert Semaphore__MerkleTreeRootIsNotPartOfTheGroup();
             }
 
-            if (block.timestamp > merkleRootCreationDate + merkleRootDuration) {
+            if (block.timestamp > merkleRootCreationDate + merkleTreeDuration) {
                 revert Semaphore__MerkleTreeRootIsExpired();
             }
         }

--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -75,7 +75,11 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
     }
 
     /// @dev See {ISemaphore-updateGroupMerkleTreeDuration}.
-    function updateGroupMerkleTreeDuration(uint256 groupId, uint256 newMerkleTreeDuration) external override onlyGroupAdmin(groupId) {
+    function updateGroupMerkleTreeDuration(uint256 groupId, uint256 newMerkleTreeDuration)
+        external
+        override
+        onlyGroupAdmin(groupId)
+    {
         uint256 oldMerkleTreeDuration = groups[groupId].merkleTreeDuration;
 
         groups[groupId].merkleTreeDuration = newMerkleTreeDuration;

--- a/packages/contracts/contracts/interfaces/ISemaphore.sol
+++ b/packages/contracts/contracts/interfaces/ISemaphore.sol
@@ -10,15 +10,10 @@ interface ISemaphore {
     error Semaphore__MerkleTreeRootIsNotPartOfTheGroup();
     error Semaphore__YouAreUsingTheSameNillifierTwice();
 
-    struct Verifier {
-        address contractAddress;
-        uint256 merkleTreeDepth;
-    }
-
     /// It defines all the group parameters, in addition to those in the Merkle tree.
     struct Group {
         address admin;
-        uint256 merkleRootDuration;
+        uint256 merkleTreeDuration;
         mapping(uint256 => uint256) merkleRootCreationDates;
         mapping(uint256 => bool) nullifierHashes;
     }
@@ -28,6 +23,16 @@ interface ISemaphore {
     /// @param oldAdmin: Old admin of the group.
     /// @param newAdmin: New admin of the group.
     event GroupAdminUpdated(uint256 indexed groupId, address indexed oldAdmin, address indexed newAdmin);
+
+    /// @dev Emitted when the Merkle tree duration of a group is updated.
+    /// @param groupId: Id of the group.
+    /// @param oldMerkleTreeDuration: Old Merkle tree duration of the group.
+    /// @param newMerkleTreeDuration: New Merkle tree duration of the group.
+    event GroupMerkleTreeDurationUpdated(
+        uint256 indexed groupId,
+        uint256 oldMerkleTreeDuration,
+        uint256 newMerkleTreeDuration
+    );
 
     /// @dev Emitted when a Semaphore proof is verified.
     /// @param groupId: Id of the group.
@@ -90,6 +95,11 @@ interface ISemaphore {
     /// @param groupId: Id of the group.
     /// @param newAdmin: New admin of the group.
     function updateGroupAdmin(uint256 groupId, address newAdmin) external;
+
+    /// @dev Updates the group Merkle tree duration.
+    /// @param groupId: Id of the group.
+    /// @param newMerkleTreeDuration: New Merkle tree duration.
+    function updateGroupMerkleTreeDuration(uint256 groupId, uint256 newMerkleTreeDuration) external;
 
     /// @dev Adds a new member to an existing group.
     /// @param groupId: Id of the group.

--- a/packages/contracts/test/Semaphore.ts
+++ b/packages/contracts/test/Semaphore.ts
@@ -82,6 +82,25 @@ describe("Semaphore", () => {
         })
     })
 
+    describe("# updateGroupMerkleTreeDuration", () => {
+        it("Should not update a group Merkle tree duration if the caller is not the group admin", async () => {
+            const transaction = semaphoreContract.updateGroupMerkleTreeDuration(groupId, 300)
+
+            await expect(transaction).to.be.revertedWithCustomError(
+                semaphoreContract,
+                "Semaphore__CallerIsNotTheGroupAdmin"
+            )
+        })
+
+        it("Should update the group Merkle tree duration", async () => {
+            const transaction = semaphoreContract.connect(signers[1]).updateGroupMerkleTreeDuration(groupId, 300)
+
+            await expect(transaction)
+                .to.emit(semaphoreContract, "GroupMerkleTreeDurationUpdated")
+                .withArgs(groupId, 3600, 300)
+        })
+    })
+
     describe("# updateGroupAdmin", () => {
         it("Should not update a group admin if the caller is not the group admin", async () => {
             const transaction = semaphoreContract.updateGroupAdmin(groupId, accounts[0])


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds a function to allow admins to update the Merkle tree duration of their group.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #200

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This bug was found by [Veridise](https://veridise.com/) during their audit of Semaphore.
