### PR TITLE
One nullifierHashes mapping for each poll

### DIFF
--- a/packages/contracts/contracts/interfaces/ISemaphoreVoting.sol
+++ b/packages/contracts/contracts/interfaces/ISemaphoreVoting.sol
@@ -23,6 +23,7 @@ interface ISemaphoreVoting {
     struct Poll {
         address coordinator;
         PollState state;
+        mapping(uint256 => bool) nullifierHashes;
     }
 
     /// @dev Emitted when a new poll is created.


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PRs removes the old `nullifierHashes` mapping from the `SemaphoreVoting.sol` contract and creates a new one within the poll struct, so that there's one different list of nullifier hashes for each poll. 

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #211 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
