### PR TITLE
Arbitrum subgraph

### DIFF
--- a/packages/subgraph/src/getURL.ts
+++ b/packages/subgraph/src/getURL.ts
@@ -9,8 +9,8 @@ export default function getURL(network: Network): string {
     switch (network) {
         case "goerli":
             return `https://api.thegraph.com/subgraphs/name/semaphore-protocol/goerli-89490c`
-        // case "arbitrum":
-        // return `https://api.thegraph.com/subgraphs/name/semaphore-protocol/arbitrum-86337c`
+        case "arbitrum":
+            return `https://api.thegraph.com/subgraphs/name/semaphore-protocol/arbitrum-72dca3`
         default:
             throw new TypeError(`Network '${network}' is not supported`)
     }

--- a/packages/subgraph/src/subgraph.test.ts
+++ b/packages/subgraph/src/subgraph.test.ts
@@ -14,10 +14,10 @@ describe("Subgraph", () => {
     describe("# Subgraph", () => {
         it("Should instantiate a subgraph object", () => {
             subgraph = new Subgraph("goerli")
-            // const subgraph1 = new Subgraph()
+            const subgraph1 = new Subgraph()
 
             expect(subgraph.url).toContain("goerli")
-            // expect(subgraph1.url).toContain("arbitrum")
+            expect(subgraph1.url).toContain("arbitrum")
         })
 
         it("Should throw an error if there is a wrong network", () => {

--- a/packages/subgraph/src/subgraph.ts
+++ b/packages/subgraph/src/subgraph.ts
@@ -11,7 +11,7 @@ export default class Subgraph {
      * Initializes the subgraph object with one of the supported networks.
      * @param network Supported Semaphore network.
      */
-    constructor(network: Network = "goerli") {
+    constructor(network: Network = "arbitrum") {
         checkParameter(network, "network", "string")
 
         this._url = getURL(network)

--- a/packages/subgraph/src/types/index.ts
+++ b/packages/subgraph/src/types/index.ts
@@ -1,4 +1,4 @@
-export type Network = "goerli" // | "arbitrum"
+export type Network = "goerli" | "arbitrum"
 
 export type GroupOptions = {
     members?: boolean


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds support for the Arbitrum subgraph to the `@semaphore-protocol/subgraph` library.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #229 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
