### PR TITLE
Group class `id` attribute

### DIFF
--- a/packages/group/src/group.test.ts
+++ b/packages/group/src/group.test.ts
@@ -6,6 +6,7 @@ describe("Group", () => {
         it("Should create a group", () => {
             const group = new Group(1)
 
+            expect(group.id).toBe(1)
             expect(group.root.toString()).toContain("103543")
             expect(group.depth).toBe(20)
             expect(group.zeroValue).toBe(hash(1))

--- a/packages/group/src/group.ts
+++ b/packages/group/src/group.ts
@@ -1,29 +1,40 @@
 import { IncrementalMerkleTree, MerkleProof } from "@zk-kit/incremental-merkle-tree"
 import poseidon from "poseidon-lite"
 import hash from "./hash"
-import { Member } from "./types"
+import { BigNumberish } from "./types"
 
 export default class Group {
+    private _id: BigNumberish
+
     merkleTree: IncrementalMerkleTree
 
     /**
      * Initializes the group with the group id and the tree depth.
-     * @param groupId Group identifier.
+     * @param id Group identifier.
      * @param treeDepth Tree depth.
      */
-    constructor(groupId: Member, treeDepth = 20) {
+    constructor(id: BigNumberish, treeDepth = 20) {
         if (treeDepth < 16 || treeDepth > 32) {
             throw new Error("The tree depth must be between 16 and 32")
         }
 
-        this.merkleTree = new IncrementalMerkleTree(poseidon, treeDepth, hash(groupId), 2)
+        this._id = id
+        this.merkleTree = new IncrementalMerkleTree(poseidon, treeDepth, hash(id), 2)
+    }
+
+    /**
+     * Returns the id of the group.
+     * @returns Group id.
+     */
+    get id(): BigNumberish {
+        return this._id
     }
 
     /**
      * Returns the root hash of the tree.
      * @returns Root hash.
      */
-    get root(): Member {
+    get root(): BigNumberish {
         return this.merkleTree.root
     }
 
@@ -39,7 +50,7 @@ export default class Group {
      * Returns the zero value of the tree.
      * @returns Tree zero value.
      */
-    get zeroValue(): Member {
+    get zeroValue(): BigNumberish {
         return this.merkleTree.zeroes[0]
     }
 
@@ -47,7 +58,7 @@ export default class Group {
      * Returns the members (i.e. identity commitments) of the group.
      * @returns List of members.
      */
-    get members(): Member[] {
+    get members(): BigNumberish[] {
         return this.merkleTree.leaves
     }
 
@@ -56,7 +67,7 @@ export default class Group {
      * @param member Group member.
      * @returns Index of the member.
      */
-    indexOf(member: Member): number {
+    indexOf(member: BigNumberish): number {
         return this.merkleTree.indexOf(member)
     }
 
@@ -64,7 +75,7 @@ export default class Group {
      * Adds a new member to the group.
      * @param member New member.
      */
-    addMember(member: Member) {
+    addMember(member: BigNumberish) {
         this.merkleTree.insert(BigInt(member))
     }
 
@@ -72,7 +83,7 @@ export default class Group {
      * Adds new members to the group.
      * @param members New members.
      */
-    addMembers(members: Member[]) {
+    addMembers(members: BigNumberish[]) {
         for (const member of members) {
             this.addMember(member)
         }
@@ -83,7 +94,7 @@ export default class Group {
      * @param index Index of the member to be updated.
      * @param member New member value.
      */
-    updateMember(index: number, member: Member) {
+    updateMember(index: number, member: BigNumberish) {
         this.merkleTree.update(index, member)
     }
 

--- a/packages/group/src/types/index.ts
+++ b/packages/group/src/types/index.ts
@@ -1,1 +1,1 @@
-export type Member = string | number | bigint
+export type BigNumberish = string | number | bigint;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds the `id` attribute to the `Group` class in the `@semaphore-protocol/group` package.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #240 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->