### PR TITLE
Integrate Inquirer.js in create command in the CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
         "commander": "^9.4.1",
         "download": "^8.0.0",
         "figlet": "^1.5.2",
+        "inquirer": "^9.1.4",
         "log-symbols": "^5.1.0",
         "ora": "^6.1.2",
         "semver": "^7.3.8"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,8 +34,6 @@ program
     .argument("[project-directory]", "Directory of the project.")
     // .option("-t, --template <template-name>", "Supported Semaphore template.", "hardhat")
     .action(async (projectDirectory) => {
-        let projectDir: string
-
         if (!projectDirectory) {
             const answers = await inquirer.prompt({
                 name: "project_name",
@@ -43,17 +41,15 @@ program
                 message: "Enter your project name:",
                 default: "my-app"
             })
-            projectDir = answers.project_name
-        } else {
-            projectDir = projectDirectory
+            projectDirectory = answers.project_name
         }
 
         const currentDirectory = process.cwd()
-        const spinner = new Spinner(`Creating your project in ${chalk.green(`./${projectDir}`)}`)
+        const spinner = new Spinner(`Creating your project in ${chalk.green(`./${projectDirectory}`)}`)
         const templateURL = `https://registry.npmjs.org/@semaphore-protocol/cli-template-hardhat/-/cli-template-hardhat-${version}.tgz`
 
-        if (existsSync(projectDir)) {
-            console.info(`\n ${logSymbols.error}`, `error: the '${projectDir}' folder already exists\n`)
+        if (existsSync(projectDirectory)) {
+            console.info(`\n ${logSymbols.error}`, `error: the '${projectDirectory}' folder already exists\n`)
             return
         }
 
@@ -63,16 +59,16 @@ program
 
         await download(templateURL, currentDirectory, { extract: true })
 
-        renameSync(`${currentDirectory}/package`, `${currentDirectory}/${projectDir}`)
+        renameSync(`${currentDirectory}/package`, `${currentDirectory}/${projectDirectory}`)
 
         spinner.stop()
 
         console.info(`\n ${logSymbols.success}`, `Your project is ready!\n`)
         console.info(` Please, install your dependencies by running:\n`)
-        console.info(`   ${chalk.cyan("cd")} ${projectDir}`)
+        console.info(`   ${chalk.cyan("cd")} ${projectDirectory}`)
         console.info(`   ${chalk.cyan("npm i")}\n`)
 
-        const { scripts } = JSON.parse(readFileSync(`${currentDirectory}/${projectDir}/package.json`, "utf8"))
+        const { scripts } = JSON.parse(readFileSync(`${currentDirectory}/${projectDirectory}/package.json`, "utf8"))
 
         if (scripts) {
             console.info(` Available scripts:\n`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3122,6 +3122,7 @@ __metadata:
     commander: ^9.4.1
     download: ^8.0.0
     figlet: ^1.5.2
+    inquirer: ^9.1.4
     log-symbols: ^5.1.0
     ora: ^6.1.2
     rollup-plugin-cleanup: ^3.2.1
@@ -4388,6 +4389,15 @@ __metadata:
   dependencies:
     type-fest: ^0.21.3
   checksum: 93111c42189c0a6bed9cdb4d7f2829548e943827ee8479c74d6e0b22ee127b2a21d3f8b5ca57723b8ef78ce011fbfc2784350eb2bde3ccfccf2f575fa8489815
+  languageName: node
+  linkType: hard
+
+"ansi-escapes@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "ansi-escapes@npm:6.0.0"
+  dependencies:
+    type-fest: ^3.0.0
+  checksum: 1ddc0b27b1d040c3c703c9cd80ee0a103817e2f9fa8f1adf0c66e970b57543ec60effdb0bd1a396ed7182bca3b1a0d8fda60ec61fee862d353db81b1c3650a78
   languageName: node
   linkType: hard
 
@@ -5967,6 +5977,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-width@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "cli-width@npm:4.0.0"
+  checksum: 1ec12311217cc8b2d018646a58b61424d2348def598fb58ba2c32e28f0bcb59a35cef168110311cefe3340abf00e5171b351de6c3e2c084bd1642e6e2a9e144e
+  languageName: node
+  linkType: hard
+
 "cliui@npm:^5.0.0":
   version: 5.0.0
   resolution: "cliui@npm:5.0.0"
@@ -7398,6 +7415,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "escape-string-regexp@npm:5.0.0"
+  checksum: 20daabe197f3cb198ec28546deebcf24b3dbb1a5a269184381b3116d12f0532e06007f4bc8da25669d6a7f8efb68db0758df4cd981f57bc5b57f521a3e12c59e
+  languageName: node
+  linkType: hard
+
 "escodegen@npm:1.8.x":
   version: 1.8.1
   resolution: "escodegen@npm:1.8.1"
@@ -8386,6 +8410,16 @@ __metadata:
   dependencies:
     escape-string-regexp: ^1.0.5
   checksum: 85a6ad29e9aca80b49b817e7c89ecc4716ff14e3779d9835af554db91bac41c0f289c418923519392a1e582b4d10482ad282021330cd045bb7b80c84152f2a2b
+  languageName: node
+  linkType: hard
+
+"figures@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "figures@npm:5.0.0"
+  dependencies:
+    escape-string-regexp: ^5.0.0
+    is-unicode-supported: ^1.2.0
+  checksum: e6e8b6d1df2f554d4effae4a5ceff5d796f9449f6d4e912d74dab7d5f25916ecda6c305b9084833157d56485a0c78b37164430ddc5675bcee1330e346710669e
   languageName: node
   linkType: hard
 
@@ -10094,6 +10128,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inquirer@npm:^9.1.4":
+  version: 9.1.4
+  resolution: "inquirer@npm:9.1.4"
+  dependencies:
+    ansi-escapes: ^6.0.0
+    chalk: ^5.1.2
+    cli-cursor: ^4.0.0
+    cli-width: ^4.0.0
+    external-editor: ^3.0.3
+    figures: ^5.0.0
+    lodash: ^4.17.21
+    mute-stream: 0.0.8
+    ora: ^6.1.2
+    run-async: ^2.4.0
+    rxjs: ^7.5.7
+    string-width: ^5.1.2
+    strip-ansi: ^7.0.1
+    through: ^2.3.6
+    wrap-ansi: ^8.0.1
+  checksum: b9acb56dfc01fdc3aac5997260b9c88b84893e270254cb67a8bef8d074d2deeea500963e69247510f1790a6b656b0a11e981441d084ce6d906e7e2a7c5441aa2
+  languageName: node
+  linkType: hard
+
 "internal-slot@npm:^1.0.3":
   version: 1.0.3
   resolution: "internal-slot@npm:1.0.3"
@@ -10476,7 +10533,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-unicode-supported@npm:^1.1.0":
+"is-unicode-supported@npm:^1.1.0, is-unicode-supported@npm:^1.2.0":
   version: 1.3.0
   resolution: "is-unicode-supported@npm:1.3.0"
   checksum: 20a1fc161afafaf49243551a5ac33b6c4cf0bbcce369fcd8f2951fbdd000c30698ce320de3ee6830497310a8f41880f8066d440aa3eb0a853e2aa4836dd89abc
@@ -14435,6 +14492,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^7.5.7":
+  version: 7.8.0
+  resolution: "rxjs@npm:7.8.0"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 61b4d4fd323c1043d8d6ceb91f24183b28bcf5def4f01ca111511d5c6b66755bc5578587fe714ef5d67cf4c9f2e26f4490d4e1d8cabf9bd5967687835e9866a2
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
@@ -16084,6 +16150,13 @@ __metadata:
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: a4ef07ece297c9fba78fc1bd6d85dff4472fe043ede98bd4710d2615d15776902b595abf62bd78339ed6278f021235fb28a96361f8be86ed754f778973a0d278
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^3.0.0":
+  version: 3.5.6
+  resolution: "type-fest@npm:3.5.6"
+  checksum: ce80d778c35280e967796b99989b796a75f8c2b6c8f1b88eb62990107f5fa90c30fdb1826fe5e2ab192e5c1eef7de6f29d133b443e80c753cbc020b01a32487a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Integrate Inquirer.js in `create` command in the CLI so that when running `semaphore create` without the project name, a question appears to get the project name. 

## Related Issue

Closes #192 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
