### PR TITLE
feat(identity): prepend hex strings with 0x

### DIFF
--- a/packages/identity/src/identity.test.ts
+++ b/packages/identity/src/identity.test.ts
@@ -45,7 +45,7 @@ describe("Identity", () => {
         it("Should not recreate an existing invalid identity", () => {
             const fun = () => new Identity('[true, "01323"]')
 
-            expect(fun).toThrow("invalid BigNumber string")
+            expect(fun).toThrow("invalid BigNumber value")
         })
 
         it("Should recreate an existing identity", () => {
@@ -102,8 +102,8 @@ describe("Identity", () => {
 
             const [trapdoor, nullifier] = JSON.parse(identity.toString())
 
-            expect(BigNumber.from(`0x${trapdoor}`).toBigInt()).toBe(identity.trapdoor)
-            expect(BigNumber.from(`0x${nullifier}`).toBigInt()).toBe(identity.nullifier)
+            expect(BigNumber.from(trapdoor).toBigInt()).toBe(identity.trapdoor)
+            expect(BigNumber.from(nullifier).toBigInt()).toBe(identity.nullifier)
         })
     })
 })

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -35,8 +35,8 @@ export default class Identity {
 
         const [trapdoor, nullifier] = JSON.parse(identityOrMessage)
 
-        this._trapdoor = BigNumber.from(`0x${trapdoor}`).toBigInt()
-        this._nullifier = BigNumber.from(`0x${nullifier}`).toBigInt()
+        this._trapdoor = BigNumber.from(trapdoor).toBigInt()
+        this._nullifier = BigNumber.from(nullifier).toBigInt()
         this._commitment = generateCommitment(this._nullifier, this._trapdoor)
     }
 
@@ -94,6 +94,6 @@ export default class Identity {
      * @returns The string representation of the identity.
      */
     public toString(): string {
-        return JSON.stringify([this._trapdoor.toString(16), this._nullifier.toString(16)])
+        return JSON.stringify([`0x${this._trapdoor.toString(16)}`, `0x${this._nullifier.toString(16)}`])
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prepend `0x` to hex strings in JSON representations of identity.

## Related Issue

Closes #260 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
