### PR TITLE
Correct check for group existence

### DIFF
--- a/packages/data/src/ethers.test.ts
+++ b/packages/data/src/ethers.test.ts
@@ -28,7 +28,8 @@ describe("SemaphoreEthers", () => {
         it("Should instantiate a SemaphoreEthers object with different networks", () => {
             semaphore = new SemaphoreEthers()
             const semaphore1 = new SemaphoreEthers("arbitrum")
-            const semaphore2 = new SemaphoreEthers("homestead", {
+            const semaphore2 = new SemaphoreEthers("matic")
+            const semaphore3 = new SemaphoreEthers("homestead", {
                 address: "0x0000000000000000000000000000000000000000",
                 startBlock: 0
             })
@@ -36,9 +37,10 @@ describe("SemaphoreEthers", () => {
             expect(semaphore.network).toBe("goerli")
             expect(semaphore.contract).toBeInstanceOf(Object)
             expect(semaphore1.network).toBe("arbitrum")
-            expect(semaphore2.network).toBe("homestead")
-            expect(semaphore2.options.startBlock).toBe(0)
-            expect(semaphore2.options.address).toContain("0x000000")
+            expect(semaphore2.network).toBe("maticmum")
+            expect(semaphore3.network).toBe("homestead")
+            expect(semaphore3.options.startBlock).toBe(0)
+            expect(semaphore3.options.address).toContain("0x000000")
         })
 
         it("Should instantiate a SemaphoreEthers object with different providers", () => {
@@ -249,6 +251,14 @@ describe("SemaphoreEthers", () => {
 
     describe("# getGroupVerifiedProofs", () => {
         it("Should return a list of group verified proofs", async () => {
+            getEventsMocked.mockReturnValueOnce(
+                Promise.resolve([
+                    {
+                        merkleTreeDepth: "20",
+                        zeroValue: "0"
+                    }
+                ])
+            )
             getEventsMocked.mockReturnValueOnce(
                 Promise.resolve([
                     {

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -246,16 +246,18 @@ export default class SemaphoreEthers {
     async getGroupVerifiedProofs(groupId: string): Promise<any> {
         checkParameter(groupId, "groupId", "string")
 
+        const [groupCreatedEvent] = await getEvents(this._contract, "GroupCreated", [groupId], this._options.startBlock)
+
+        if (!groupCreatedEvent) {
+            throw new Error(`Group '${groupId}' not found`)
+        }
+
         const proofVerifiedEvents = await getEvents(
             this._contract,
             "ProofVerified",
             [groupId],
             this._options.startBlock
         )
-
-        if (proofVerifiedEvents.length === 0) {
-            throw new Error(`Group '${groupId}' not found`)
-        }
 
         return proofVerifiedEvents.map((event) => ({
             signal: event.signal.toString(),


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes a bug in the `@semaphore-protocol/data` package, in which the `SemaphoreEthers.getGroupVerifiedProofs` function currently throws an error even when the group actually exists.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
