### PR TITLE
New default network (Sepolia)

### DIFF
--- a/packages/data/src/ethers.test.ts
+++ b/packages/data/src/ethers.test.ts
@@ -29,18 +29,20 @@ describe("SemaphoreEthers", () => {
             semaphore = new SemaphoreEthers()
             const semaphore1 = new SemaphoreEthers("arbitrum")
             const semaphore2 = new SemaphoreEthers("matic")
-            const semaphore3 = new SemaphoreEthers("homestead", {
+            const semaphore3 = new SemaphoreEthers("optimism-goerli")
+            const semaphore4 = new SemaphoreEthers("homestead", {
                 address: "0x0000000000000000000000000000000000000000",
                 startBlock: 0
             })
 
-            expect(semaphore.network).toBe("goerli")
+            expect(semaphore.network).toBe("sepolia")
             expect(semaphore.contract).toBeInstanceOf(Object)
             expect(semaphore1.network).toBe("arbitrum")
             expect(semaphore2.network).toBe("maticmum")
-            expect(semaphore3.network).toBe("homestead")
-            expect(semaphore3.options.startBlock).toBe(0)
-            expect(semaphore3.options.address).toContain("0x000000")
+            expect(semaphore3.network).toBe("optimism-goerli")
+            expect(semaphore4.network).toBe("homestead")
+            expect(semaphore4.options.startBlock).toBe(0)
+            expect(semaphore4.options.address).toContain("0x000000")
         })
 
         it("Should instantiate a SemaphoreEthers object with different providers", () => {

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -24,7 +24,7 @@ export default class SemaphoreEthers {
      * @param networkOrEthereumURL Ethereum network or custom URL.
      * @param options Ethers options.
      */
-    constructor(networkOrEthereumURL: Network | string = "goerli", options: EthersOptions = {}) {
+    constructor(networkOrEthereumURL: Network | string = "sepolia", options: EthersOptions = {}) {
         checkParameter(networkOrEthereumURL, "networkOrSubgraphURL", "string")
 
         if (options.provider) {
@@ -53,6 +53,14 @@ export default class SemaphoreEthers {
             case "goerli":
                 options.address = "0x89490c95eD199D980Cdb4FF8Bac9977EDb41A7E7"
                 options.startBlock = 8255063
+                break
+            case "sepolia":
+                options.address = "0x220fBdB6F996827b1Cf12f0C181E8d5e6de3a36F"
+                options.startBlock = 3053948
+                break
+            case "optimism-goerli":
+                options.address = "0x220fBdB6F996827b1Cf12f0C181E8d5e6de3a36F"
+                options.startBlock = 6477953
                 break
             default:
                 if (options.address === undefined) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PRs set Sepolia as a default network for the `SemaphoreEthers` class.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #277 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
