### PR TITLE
chore: bump poseidon-lite minor version

### DIFF
--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -32,7 +32,7 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-node-resolve": "^15.0.1",
-        "poseidon-lite": "^0.1.0",
+        "poseidon-lite": "^0.2.0",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-typescript2": "^0.31.2",
         "typedoc": "^0.22.11"

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -32,7 +32,7 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-node-resolve": "^15.0.1",
-        "poseidon-lite": "^0.1.0",
+        "poseidon-lite": "^0.2.0",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-typescript2": "^0.31.2",
         "typedoc": "^0.22.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4403,7 +4403,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^24.0.1
     "@rollup/plugin-node-resolve": ^15.0.1
     "@zk-kit/incremental-merkle-tree": 1.0.0
-    poseidon-lite: ^0.1.0
+    poseidon-lite: ^0.2.0
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2
     typedoc: ^0.22.11
@@ -4451,7 +4451,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^24.0.1
     "@rollup/plugin-node-resolve": ^15.0.1
     js-sha512: ^0.8.0
-    poseidon-lite: ^0.1.0
+    poseidon-lite: ^0.2.0
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2
     typedoc: ^0.22.11
@@ -16183,10 +16183,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"poseidon-lite@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "poseidon-lite@npm:0.1.0"
-  checksum: 947d339ef4a8ab61e0dc7ddf567514afa7c51f862bb40cb204389335d0b56cf0fc7d66baa4a93f57f9c939691579fd0f8da641d416a5335e30a64c43b1c95204
+"poseidon-lite@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "poseidon-lite@npm:0.2.0"
+  checksum: c47c6fd0a29a78ca1f7cf6ccb8b0c4f4e72930d944e63425e36f60c15d37fb0aeca30b8a22a30640ed68d631142282c0b8308da83b1a2b2bb92b87f5a2432c93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Uses the new version of `poseidon-lite`, which is MIT licensed and ~4x faster.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
