### PR TITLE
New function to calculate nullifier hash

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,5 +41,6 @@ jobs:
               with:
                   build_dir: docs
                   jekyll: false
+                  fqdn: js.semaphore.appliedzkp.org
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The core of the Semaphore protocol is in the [circuit logic](/packages/circuits/
                 <a href="/packages/identity">
                     @semaphore-protocol/identity
                 </a>
-                <a href="https://semaphore-protocol.github.io/semaphore/identity">
+                <a href="https://js.semaphore.appliedzkp.org/identity">
                     (docs)
                 </a>
             </td>
@@ -116,7 +116,7 @@ The core of the Semaphore protocol is in the [circuit logic](/packages/circuits/
                 <a href="/packages/group">
                     @semaphore-protocol/group
                 </a>
-                <a href="https://semaphore-protocol.github.io/semaphore/group">
+                <a href="https://js.semaphore.appliedzkp.org/group">
                     (docs)
                 </a>
             </td>
@@ -138,7 +138,7 @@ The core of the Semaphore protocol is in the [circuit logic](/packages/circuits/
                 <a href="/packages/proof">
                     @semaphore-protocol/proof
                 </a>
-                <a href="https://semaphore-protocol.github.io/semaphore/proof">
+                <a href="https://js.semaphore.appliedzkp.org/proof">
                     (docs)
                 </a>
             </td>
@@ -160,7 +160,7 @@ The core of the Semaphore protocol is in the [circuit logic](/packages/circuits/
                 <a href="/packages/data">
                     @semaphore-protocol/data
                 </a>
-                <a href="https://semaphore-protocol.github.io/semaphore/data">
+                <a href="https://js.semaphore.appliedzkp.org/data">
                     (docs)
                 </a>
             </td>
@@ -220,7 +220,7 @@ The core of the Semaphore protocol is in the [circuit logic](/packages/circuits/
                 <a href="/packages/heyauthn">
                     @semaphore-protocol/heyauthn
                 </a>
-                <a href="https://semaphore-protocol.github.io/semaphore/heyauthn">
+                <a href="https://js.semaphore.appliedzkp.org/heyauthn">
                     (docs)
                 </a>
             </td>

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -18,6 +18,9 @@
     <a href="https://npmjs.org/package/@semaphore-protocol/data">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@semaphore-protocol/data.svg?style=flat-square" />
     </a>
+    <a href="https://js.semaphore.appliedzkp.org/data">
+        <img alt="Documentation typedoc" src="https://img.shields.io/badge/docs-typedoc-744C7C?style=flat-square">
+    </a>
     <a href="https://eslint.org/">
         <img alt="Linter eslint" src="https://img.shields.io/badge/linter-eslint-8080f2?style=flat-square&logo=eslint" />
     </a>

--- a/packages/group/README.md
+++ b/packages/group/README.md
@@ -18,6 +18,9 @@
     <a href="https://npmjs.org/package/@semaphore-protocol/group">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@semaphore-protocol/group.svg?style=flat-square" />
     </a>
+    <a href="https://js.semaphore.appliedzkp.org/group">
+        <img alt="Documentation typedoc" src="https://img.shields.io/badge/docs-typedoc-744C7C?style=flat-square">
+    </a>
     <a href="https://eslint.org/">
         <img alt="Linter eslint" src="https://img.shields.io/badge/linter-eslint-8080f2?style=flat-square&logo=eslint" />
     </a>

--- a/packages/heyauthn/README.md
+++ b/packages/heyauthn/README.md
@@ -18,6 +18,9 @@
     <a href="https://npmjs.org/package/@semaphore-protocol/heyauthn">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@semaphore-protocol/heyauthn.svg?style=flat-square" />
     </a>
+    <a href="https://js.semaphore.appliedzkp.org/heyauthn">
+        <img alt="Documentation typedoc" src="https://img.shields.io/badge/docs-typedoc-744C7C?style=flat-square">
+    </a>
     <a href="https://eslint.org/">
         <img alt="Linter eslint" src="https://img.shields.io/badge/linter-eslint-8080f2?style=flat-square&logo=eslint" />
     </a>

--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -18,6 +18,9 @@
     <a href="https://npmjs.org/package/@semaphore-protocol/identity">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@semaphore-protocol/identity.svg?style=flat-square" />
     </a>
+    <a href="https://js.semaphore.appliedzkp.org/identity">
+        <img alt="Documentation typedoc" src="https://img.shields.io/badge/docs-typedoc-744C7C?style=flat-square">
+    </a>
     <a href="https://eslint.org/">
         <img alt="Linter eslint" src="https://img.shields.io/badge/linter-eslint-8080f2?style=flat-square&logo=eslint" />
     </a>

--- a/packages/proof/README.md
+++ b/packages/proof/README.md
@@ -108,7 +108,7 @@ await verifyProof(fullProof, 20)
 \# **calculateNullifierHash**(
 identityNullifier: _bigint | number | string_,
 externalNullifier: \__BytesLike | Hexable | number | bigint_
-): Promise\<_boolean_>
+): bigint
 
 ```typescript
 import { Identity } from "@semaphore-protocol/identity"

--- a/packages/proof/README.md
+++ b/packages/proof/README.md
@@ -67,7 +67,13 @@ yarn add @semaphore-protocol/identity @semaphore-protocol/group @semaphore-proto
 
 ## 📜 Usage
 
-\# **generateProof**(identity: _Identity_, group: _Group_ | _MerkleProof_, externalNullifier: _BigNumberish_, signal: _string_, snarkArtifacts?: _SnarkArtifacts_): Promise\<_SemaphoreFullProof_>
+\# **generateProof**(
+identity: _Identity_,
+group: _Group_ | _MerkleProof_,
+externalNullifier: _BytesLike | Hexable | number | bigint_,
+signal: _BytesLike | Hexable | number | bigint_,
+snarkArtifacts?: _SnarkArtifacts_
+): Promise\<_SemaphoreFullProof_>
 
 ```typescript
 import { Identity } from "@semaphore-protocol/identity"
@@ -97,4 +103,19 @@ const fullProof = await generateProof(identity, group, externalNullifier, signal
 import { verifyProof } from "@semaphore-protocol/proof"
 
 await verifyProof(fullProof, 20)
+```
+
+\# **calculateNullifierHash**(
+identityNullifier: _bigint | number | string_,
+externalNullifier: \__BytesLike | Hexable | number | bigint_
+): Promise\<_boolean_>
+
+```typescript
+import { Identity } from "@semaphore-protocol/identity"
+import { calculateNullifierHash } from "@semaphore-protocol/proof"
+
+const identity = new Identity()
+const externalNullifier = utils.formatBytes32String("Topic")
+
+const nullifierHash = calculateNullifierHash(identity.nullifier, externalNullifier)
 ```

--- a/packages/proof/README.md
+++ b/packages/proof/README.md
@@ -18,6 +18,9 @@
     <a href="https://npmjs.org/package/@semaphore-protocol/proof">
         <img alt="Downloads" src="https://img.shields.io/npm/dm/@semaphore-protocol/proof.svg?style=flat-square" />
     </a>
+    <a href="https://js.semaphore.appliedzkp.org/proof">
+        <img alt="Documentation typedoc" src="https://img.shields.io/badge/docs-typedoc-744C7C?style=flat-square">
+    </a>
     <a href="https://eslint.org/">
         <img alt="Linter eslint" src="https://img.shields.io/badge/linter-eslint-8080f2?style=flat-square&logo=eslint" />
     </a>

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -30,8 +30,11 @@
         "access": "public"
     },
     "devDependencies": {
+        "@rollup/plugin-commonjs": "^24.1.0",
         "@rollup/plugin-json": "^5.0.1",
+        "@rollup/plugin-node-resolve": "^15.0.2",
         "ffjavascript": "^0.2.54",
+        "poseidon-lite": "^0.2.0",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-typescript2": "^0.31.2",
         "typedoc": "^0.22.11"

--- a/packages/proof/rollup.config.ts
+++ b/packages/proof/rollup.config.ts
@@ -1,7 +1,9 @@
 import typescript from "rollup-plugin-typescript2"
+import commonjs from "@rollup/plugin-commonjs"
 import * as fs from "fs"
 import cleanup from "rollup-plugin-cleanup"
 import json from "@rollup/plugin-json"
+import { nodeResolve } from "@rollup/plugin-node-resolve"
 
 const pkg = JSON.parse(fs.readFileSync("./package.json", "utf-8"))
 const banner = `/**
@@ -25,6 +27,8 @@ export default {
             tsconfig: "./build.tsconfig.json",
             useTsconfigDeclarationDir: true
         }),
+        commonjs(),
+        nodeResolve(),
         cleanup({ comments: "jsdoc" }),
         json()
     ]

--- a/packages/proof/src/calculateNullifierHash.ts
+++ b/packages/proof/src/calculateNullifierHash.ts
@@ -1,0 +1,16 @@
+import { BytesLike, Hexable } from "@ethersproject/bytes"
+import { poseidon2 } from "poseidon-lite/poseidon2"
+import hash from "./hash"
+
+/**
+ * Given the identity nullifier and the external nullifier, it calculates nullifier hash.
+ * @param identityNullifier The identity nullifier.
+ * @param externalNullifier The external nullifier.
+ * @returns The nullifier hash.
+ */
+export default function calculateNullifierHash(
+    identityNullifier: number | bigint | string,
+    externalNullifier: BytesLike | Hexable | number | bigint
+): bigint {
+    return poseidon2([hash(externalNullifier), identityNullifier])
+}

--- a/packages/proof/src/index.test.ts
+++ b/packages/proof/src/index.test.ts
@@ -2,6 +2,7 @@ import { formatBytes32String } from "@ethersproject/strings"
 import { Group } from "@semaphore-protocol/group"
 import { Identity } from "@semaphore-protocol/identity"
 import { getCurveFromName } from "ffjavascript"
+import calculateNullifierHash from "./calculateNullifierHash"
 import generateProof from "./generateProof"
 import hash from "./hash"
 import packProof from "./packProof"
@@ -144,6 +145,14 @@ describe("Proof", () => {
             expect(hash([2]).toString()).toBe(
                 "113682330006535319932160121224458771213356533826860247409332700812532759386"
             )
+        })
+    })
+
+    describe("# calculateNullifierHash", () => {
+        it("Should calculate the nullifier hash correctly", async () => {
+            const nullifierHash = calculateNullifierHash(identity.nullifier, externalNullifier)
+
+            expect(fullProof.nullifierHash).toBe(nullifierHash.toString())
         })
     })
 

--- a/packages/proof/src/index.ts
+++ b/packages/proof/src/index.ts
@@ -1,5 +1,6 @@
 import generateProof from "./generateProof"
 import verifyProof from "./verifyProof"
+import calculateNullifierHash from "./calculateNullifierHash"
 
-export { generateProof, verifyProof }
+export { generateProof, verifyProof, calculateNullifierHash }
 export * from "./types"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,6 +4110,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-commonjs@npm:^24.1.0":
+  version: 24.1.0
+  resolution: "@rollup/plugin-commonjs@npm:24.1.0"
+  dependencies:
+    "@rollup/pluginutils": ^5.0.1
+    commondir: ^1.0.1
+    estree-walker: ^2.0.2
+    glob: ^8.0.3
+    is-reference: 1.2.1
+    magic-string: ^0.27.0
+  peerDependencies:
+    rollup: ^2.68.0||^3.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 42faafc9bc8e04d75c86bb50d693ebb9c5eee19bf9ab3c09780b872547d12ff5ea85cfec7da75f5176d0aa4b5233101f667f44b85b331450a7bb14c95180852e
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-json@npm:^5.0.1":
   version: 5.0.2
   resolution: "@rollup/plugin-json@npm:5.0.2"
@@ -4170,6 +4189,25 @@ __metadata:
     rollup:
       optional: true
   checksum: 90e30b41626a15ebf02746a83d34b15f9fe9051ddc156a9bf785504f489947980b3bdeb7bf2f80828a9becfe472a03a96d0238328a3e3e2198a482fcac7eb3aa
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-node-resolve@npm:^15.0.2":
+  version: 15.0.2
+  resolution: "@rollup/plugin-node-resolve@npm:15.0.2"
+  dependencies:
+    "@rollup/pluginutils": ^5.0.1
+    "@types/resolve": 1.20.2
+    deepmerge: ^4.2.2
+    is-builtin-module: ^3.2.1
+    is-module: ^1.0.0
+    resolve: ^1.22.1
+  peerDependencies:
+    rollup: ^2.78.0||^3.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 328eafee06ff967a36441b55e77fbd0d4f599d256e5d1977800ee71915846c46bc1b6185df35c7b512ad2b4023b05b65a332be77b8b00b9d8a20f87d056b8166
   languageName: node
   linkType: hard
 
@@ -4466,9 +4504,12 @@ __metadata:
     "@ethersproject/bytes": ^5.7.0
     "@ethersproject/keccak256": ^5.7.0
     "@ethersproject/strings": ^5.5.0
+    "@rollup/plugin-commonjs": ^24.1.0
     "@rollup/plugin-json": ^5.0.1
+    "@rollup/plugin-node-resolve": ^15.0.2
     "@zk-kit/incremental-merkle-tree": 0.4.3
     ffjavascript: ^0.2.54
+    poseidon-lite: ^0.2.0
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2
     snarkjs: 0.4.13
@@ -12164,7 +12205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-builtin-module@npm:^3.2.0":
+"is-builtin-module@npm:^3.2.0, is-builtin-module@npm:^3.2.1":
   version: 3.2.1
   resolution: "is-builtin-module@npm:3.2.1"
   dependencies:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds a new function to calculate the nullifier hash to the `@semaphore-protocol/proof` package.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
