### PR TITLE
Sepolia subgraph & supported networks

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { GroupResponse, SemaphoreEthers, SemaphoreSubgraph } from "@semaphore-protocol/data"
+import { GroupResponse, SemaphoreEthers, SemaphoreSubgraph, getSupportedNetworks } from "@semaphore-protocol/data"
 import chalk from "chalk"
 import { program } from "commander"
 import figlet from "figlet"
@@ -16,7 +16,7 @@ import Spinner from "./spinner.js"
 const packagePath = `${dirname(fileURLToPath(import.meta.url))}/..`
 const { description, version } = JSON.parse(readFileSync(`${packagePath}/package.json`, "utf8"))
 
-const supportedNetworks = ["sepolia", "goerli", "mumbai", "optimism-goerli", "arbitrum", "arbitrum-goerli"]
+const supportedNetworks = getSupportedNetworks()
 
 const supportedTemplates = [
     {

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -70,7 +70,13 @@ yarn add @semaphore-protocol/data
 
 ## 📜 Usage
 
-\# **new SemaphoreSubgraph**(networkOrSubgraphURL: _Network_ | _string_ = "goerli"): _SemaphoreSubgraph_
+\# **getSupportedNetworks**(): _string[]_
+
+```typescript
+const supportedNetworks = getSupportedNetworks()
+```
+
+\# **new SemaphoreSubgraph**(networkOrSubgraphURL: SupportedNetwork | ValueOf\<SupportedNetwork> | string = "sepolia"): _SemaphoreSubgraph_
 
 ```typescript
 import { SemaphoreSubgraph } from "@semaphore-protocol/data"

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -12,10 +12,10 @@ import {
 import checkParameter from "./checkParameter"
 import getEvents from "./getEvents"
 import SemaphoreABI from "./semaphoreABI.json"
-import { EthersOptions, GroupResponse, Network } from "./types"
+import { EthersOptions, GroupResponse, EthersNetwork } from "./types"
 
 export default class SemaphoreEthers {
-    private _network: Network | string
+    private _network: EthersNetwork | string
     private _options: EthersOptions
     private _contract: Contract
 
@@ -24,7 +24,7 @@ export default class SemaphoreEthers {
      * @param networkOrEthereumURL Ethereum network or custom URL.
      * @param options Ethers options.
      */
-    constructor(networkOrEthereumURL: Network | string = "sepolia", options: EthersOptions = {}) {
+    constructor(networkOrEthereumURL: EthersNetwork | string = "sepolia", options: EthersOptions = {}) {
         checkParameter(networkOrEthereumURL, "networkOrSubgraphURL", "string")
 
         if (options.provider) {
@@ -114,7 +114,7 @@ export default class SemaphoreEthers {
      * Returns the Ethereum network or custom URL.
      * @returns Ethereum network or custom URL.
      */
-    get network(): Network | string {
+    get network(): EthersNetwork | string {
         return this._network
     }
 

--- a/packages/data/src/getSupportedNetworks.ts
+++ b/packages/data/src/getSupportedNetworks.ts
@@ -1,0 +1,9 @@
+import { SupportedNetwork } from "./types"
+
+/**
+ * Returns the list of Semaphore supported networks.
+ * @returns Semaphore supported networks.
+ */
+export default function getSupportedNetworks(): string[] {
+    return Object.values(SupportedNetwork)
+}

--- a/packages/data/src/getURL.ts
+++ b/packages/data/src/getURL.ts
@@ -1,8 +1,8 @@
-import { Network } from "./types"
+import { SupportedNetwork } from "./types"
 
 /**
  * Returns the subgraph URL related to the network passed as a parameter.
- * @param network Semaphore supported network.
+ * @param supportedNetwork Semaphore supported network.
  * @returns Subgraph URL.
  */
 export default function getURL(supportedNetwork: SupportedNetwork | string): string {
@@ -13,8 +13,8 @@ export default function getURL(supportedNetwork: SupportedNetwork | string): str
         case "optimism-goerli":
         case "arbitrum-goerli":
         case "arbitrum":
-            return `https://api.studio.thegraph.com/query/14377/semaphore-${network}/v3.6.1`
+            return `https://api.studio.thegraph.com/query/14377/semaphore-${supportedNetwork}/v3.6.1`
         default:
-            throw new TypeError(`Network '${network}' is not supported`)
+            throw new TypeError(`Network '${supportedNetwork}' is not supported`)
     }
 }

--- a/packages/data/src/getURL.ts
+++ b/packages/data/src/getURL.ts
@@ -5,8 +5,9 @@ import { Network } from "./types"
  * @param network Semaphore supported network.
  * @returns Subgraph URL.
  */
-export default function getURL(network: Network): string {
-    switch (network) {
+export default function getURL(supportedNetwork: SupportedNetwork | string): string {
+    switch (supportedNetwork) {
+        case "sepolia":
         case "goerli":
         case "mumbai":
         case "optimism-goerli":

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1,5 +1,6 @@
-import SemaphoreSubgraph from "./subgraph"
 import SemaphoreEthers from "./ethers"
+import getSupportedNetworks from "./getSupportedNetworks"
+import SemaphoreSubgraph from "./subgraph"
 
-export { SemaphoreSubgraph, SemaphoreEthers }
 export * from "./types"
+export { SemaphoreSubgraph, SemaphoreEthers, getSupportedNetworks }

--- a/packages/data/src/subgraph.test.ts
+++ b/packages/data/src/subgraph.test.ts
@@ -16,7 +16,7 @@ describe("SemaphoreSubgraph", () => {
             semaphore = new SemaphoreSubgraph()
             const semaphore1 = new SemaphoreSubgraph("arbitrum")
 
-            expect(semaphore.url).toContain("goerli")
+            expect(semaphore.url).toContain("sepolia")
             expect(semaphore1.url).toContain("arbitrum")
         })
 

--- a/packages/data/src/subgraph.ts
+++ b/packages/data/src/subgraph.ts
@@ -2,7 +2,7 @@ import { AxiosRequestConfig } from "axios"
 import checkParameter from "./checkParameter"
 import getURL from "./getURL"
 import request from "./request"
-import { GroupResponse, GroupOptions, Network } from "./types"
+import { GroupOptions, GroupResponse, SupportedNetwork } from "./types"
 import { jsDateToGraphqlDate } from "./utils"
 
 export default class SemaphoreSubgraph {
@@ -12,15 +12,15 @@ export default class SemaphoreSubgraph {
      * Initializes the subgraph object with one of the supported networks or a custom URL.
      * @param networkOrSubgraphURL Supported Semaphore network or custom Subgraph URL.
      */
-    constructor(networkOrSubgraphURL: Network | string = "goerli") {
+    constructor(networkOrSubgraphURL: SupportedNetwork | string = SupportedNetwork.SEPOLIA) {
         checkParameter(networkOrSubgraphURL, "networkOrSubgraphURL", "string")
 
-        if (networkOrSubgraphURL.startsWith("http")) {
+        if (typeof networkOrSubgraphURL === "string" && networkOrSubgraphURL.startsWith("http")) {
             this._url = networkOrSubgraphURL
             return
         }
 
-        this._url = getURL(networkOrSubgraphURL as Network)
+        this._url = getURL(networkOrSubgraphURL)
     }
 
     /**

--- a/packages/data/src/types/index.ts
+++ b/packages/data/src/types/index.ts
@@ -1,4 +1,13 @@
-export type Network =
+export enum SupportedNetwork {
+    SEPOLIA = "sepolia",
+    GOERLI = "goerli",
+    MUMBAI = "mumbai",
+    OPTIMISM_GOERLI = "optimism-goerli",
+    ARBITRUM_GOERLI = "arbitrum-goerli",
+    ARBITRUM = "arbitrum"
+}
+
+export type EthersNetwork =
     | "homestead"
     | "matic"
     | "goerli"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds support for Sepolia subgraph and a function to get a list of Semaphore supported networks.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #314, https://github.com/semaphore-protocol/subgraph/issues/9

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->