### PR TITLE
New class parameter to add members

### DIFF
--- a/packages/group/README.md
+++ b/packages/group/README.md
@@ -74,6 +74,7 @@ yarn add @semaphore-protocol/group
 
 ```typescript
 import { Group } from "@semaphore-protocol/group"
+import { Identity } from "@semaphore-protocol/identity"
 
 // Group with max 1048576 members (20^²).
 const group1 = new Group(1)
@@ -83,6 +84,13 @@ const group2 = new Group(1, 16)
 
 // Group with max 16777216 members (24^²).
 const group3 = new Group(1, 24)
+
+// Group with a list of predefined members.
+const identity1 = new Identity()
+const identity2 = new Identity()
+const identity3 = new Identity()
+
+const group3 = new Group(1, 16, [identity1.commitment, identity2.commitment, identity3.commitment])
 ```
 
 \# **addMember**(identityCommitment: _Member_)
@@ -94,21 +102,6 @@ const identity = new Identity()
 const commitment = identity.generateCommitment()
 
 group.addMember(commitment)
-```
-
-\# **addMembers**(identityCommitments: _Member\[]_)
-
-```typescript
-let identityCommitments: bigint[]
-
-for (let i = 0; i < 10; i++) {
-    const identity = new Identity()
-    const commitment = identity.generateCommitment()
-
-    identityCommitments.push(commitment)
-}
-
-group.addMember(identityCommitments)
 ```
 
 \# **removeMember**(index: _number_)

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -41,6 +41,6 @@
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
-        "@zk-kit/incremental-merkle-tree": "1.0.0"
+        "@zk-kit/incremental-merkle-tree": "1.1.0"
     }
 }

--- a/packages/group/src/group.test.ts
+++ b/packages/group/src/group.test.ts
@@ -19,13 +19,28 @@ describe("Group", () => {
             expect(fun).toThrow("The tree depth must be between 16 and 32")
         })
 
-        it("Should create a group with different parameters", () => {
+        it("Should create a group with a different tree depth", () => {
             const group = new Group(1, 32)
 
             expect(group.root.toString()).toContain("460373")
             expect(group.depth).toBe(32)
             expect(group.zeroValue).toBe(hash(1))
             expect(group.members).toHaveLength(0)
+        })
+
+        it("Should create a group with a list of members", () => {
+            const group = new Group(2, 20, [1, 2, 3])
+
+            const group2 = new Group(2, 20)
+
+            group2.addMember(1)
+            group2.addMember(2)
+            group2.addMember(3)
+
+            expect(group.root.toString()).toContain(group2.root.toString())
+            expect(group.depth).toBe(20)
+            expect(group.zeroValue).toBe(hash(2))
+            expect(group.members).toHaveLength(3)
         })
     })
 

--- a/packages/group/src/group.ts
+++ b/packages/group/src/group.ts
@@ -12,14 +12,15 @@ export default class Group {
      * Initializes the group with the group id and the tree depth.
      * @param id Group identifier.
      * @param treeDepth Tree depth.
+     * @param members List of group members.
      */
-    constructor(id: BigNumberish, treeDepth = 20) {
+    constructor(id: BigNumberish, treeDepth = 20, members: BigNumberish[] = []) {
         if (treeDepth < 16 || treeDepth > 32) {
             throw new Error("The tree depth must be between 16 and 32")
         }
 
         this._id = id
-        this.merkleTree = new IncrementalMerkleTree(poseidon2, treeDepth, hash(id), 2)
+        this.merkleTree = new IncrementalMerkleTree(poseidon2, treeDepth, hash(id), 2, members)
     }
 
     /**
@@ -82,6 +83,7 @@ export default class Group {
     /**
      * Adds new members to the group.
      * @param members New members.
+     * @deprecated Use the new class parameter to add a list of members.
      */
     addMembers(members: BigNumberish[]) {
         for (const member of members) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,7 +4440,7 @@ __metadata:
     "@ethersproject/keccak256": ^5.7.0
     "@rollup/plugin-commonjs": ^24.0.1
     "@rollup/plugin-node-resolve": ^15.0.1
-    "@zk-kit/incremental-merkle-tree": 1.0.0
+    "@zk-kit/incremental-merkle-tree": 1.1.0
     poseidon-lite: ^0.2.0
     rollup-plugin-cleanup: ^3.2.1
     rollup-plugin-typescript2: ^0.31.2
@@ -5643,10 +5643,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zk-kit/incremental-merkle-tree@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@zk-kit/incremental-merkle-tree@npm:1.0.0"
-  checksum: 2b5d7b5cc08cf3aea536d6541a1177221fcacca5b93fb22e37cd05926d138fe69035b73cb42e09798505caf1b7a75ad225027d13d35c2f0d7b216147cafd184e
+"@zk-kit/incremental-merkle-tree@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@zk-kit/incremental-merkle-tree@npm:1.1.0"
+  checksum: 5f2d6dd2a4898aa75f72d5b3811ab965c369f0a51561250313849fb9a6a1163064c4887da3bea298d25e80a4bc79b3c6997edf6492a6a8fc157512bc3fcb5e23
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR adds a third parameter to the `Group` class, that can be used to initialize a list of member. It is more efficient than the old `addMembers` method, which is now deprecated. Times are now about 10 times faster.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #319

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
