### PR TITLE
New filter option to query groups based on identity commitment

### DIFF
--- a/packages/data/src/subgraph.ts
+++ b/packages/data/src/subgraph.ts
@@ -68,11 +68,14 @@ export default class SemaphoreSubgraph {
         let filtersQuery = ""
 
         if (options.filters) {
-            const { admin, timestamp, timestampGte, timestampLte } = options.filters
+            const { admin, identityCommitment, timestamp, timestampGte, timestampLte } = options.filters
             const filterFragments = []
 
             if (admin) {
                 filterFragments.push(`admin: "${admin}"`)
+            }
+            if (identityCommitment) {
+                filterFragments.push(`members_: { identityCommitment: "${identityCommitment}" }`)
             }
 
             /* istanbul ignore next */

--- a/packages/data/src/types/index.ts
+++ b/packages/data/src/types/index.ts
@@ -24,6 +24,7 @@ export type GroupOptions = {
     verifiedProofs?: boolean
     filters?: {
         admin?: string
+        identityCommitment?: string
         timestamp?: Date
         timestampGte?: Date
         timestampLte?: Date


### PR DESCRIPTION
I'm proposing to add an additional filter option, based on identity commitments for querying groups.
This could be useful for example, to fetch all groups that I'm part of.

## Related Issue

somewhat related to #321 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

