### PR TITLE
Check address value before setting it in `SemaphoreEthers` class

### DIFF
--- a/packages/data/src/ethers.test.ts
+++ b/packages/data/src/ethers.test.ts
@@ -31,10 +31,16 @@ describe("SemaphoreEthers", () => {
             const semaphore2 = new SemaphoreEthers("matic")
             const semaphore3 = new SemaphoreEthers("optimism-goerli")
             const semaphore4 = new SemaphoreEthers("arbitrum-goerli")
-            const semaphore5 = new SemaphoreEthers("homestead", {
+            const semaphore5 = new SemaphoreEthers("arbitrum-goerli", {
                 address: "0x0000000000000000000000000000000000000000",
                 startBlock: 0
             })
+            const semaphore6 = new SemaphoreEthers("homestead", {
+                address: "0x0000000000000000000000000000000000000000",
+                startBlock: 0
+            })
+
+            console.log(semaphore5)
 
             expect(semaphore.network).toBe("sepolia")
             expect(semaphore.contract).toBeInstanceOf(Object)
@@ -42,9 +48,10 @@ describe("SemaphoreEthers", () => {
             expect(semaphore2.network).toBe("maticmum")
             expect(semaphore3.network).toBe("optimism-goerli")
             expect(semaphore4.network).toBe("arbitrum-goerli")
-            expect(semaphore5.network).toBe("homestead")
-            expect(semaphore5.options.startBlock).toBe(0)
             expect(semaphore5.options.address).toContain("0x000000")
+            expect(semaphore6.network).toBe("homestead")
+            expect(semaphore6.options.startBlock).toBe(0)
+            expect(semaphore6.options.address).toContain("0x000000")
         })
 
         it("Should instantiate a SemaphoreEthers object with different providers", () => {

--- a/packages/data/src/ethers.test.ts
+++ b/packages/data/src/ethers.test.ts
@@ -40,8 +40,6 @@ describe("SemaphoreEthers", () => {
                 startBlock: 0
             })
 
-            console.log(semaphore5)
-
             expect(semaphore.network).toBe("sepolia")
             expect(semaphore.contract).toBeInstanceOf(Object)
             expect(semaphore1.network).toBe("arbitrum")

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -43,37 +43,35 @@ export default class SemaphoreEthers {
 
         switch (networkOrEthereumURL) {
             case "arbitrum":
-                options.address = "0xc60E0Ee1a2770d5F619858C641f14FC4a6401520"
-                options.startBlock = 77278430
+                options.address ??= "0xc60E0Ee1a2770d5F619858C641f14FC4a6401520"
+                options.startBlock ??= 77278430
                 break
             case "arbitrum-goerli":
-                options.address = "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
-                options.startBlock = 15174410
+                options.address ??= "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
+                options.startBlock ??= 15174410
                 break
             case "maticmum":
-                options.address = "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
-                options.startBlock = 33995010
+                options.address ??= "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
+                options.startBlock ??= 33995010
                 break
             case "goerli":
-                options.address = "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
-                options.startBlock = 8777695
+                options.address ??= "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
+                options.startBlock ??= 8777695
                 break
             case "sepolia":
-                options.address = "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
-                options.startBlock = 3231111
+                options.address ??= "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
+                options.startBlock ??= 3231111
                 break
             case "optimism-goerli":
-                options.address = "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
-                options.startBlock = 7632846
+                options.address ??= "0x3889927F0B5Eb1a02C6E2C20b39a1Bd4EAd76131"
+                options.startBlock ??= 7632846
                 break
             default:
                 if (options.address === undefined) {
                     throw new Error(`You should provide a Semaphore contract address for this network`)
                 }
 
-                if (options.startBlock === undefined) {
-                    options.startBlock = 0
-                }
+                options.startBlock ??= 0
         }
 
         let provider: Provider


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The code of this PR uses a nullish coalescing operator to check if the address already exists. If not, it sets the address based on the network.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #358

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
