### PR TITLE
fix: typescript type exports

### DIFF
--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -6,7 +6,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "./dist/types/index.d.ts",
     "files": [

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -6,7 +6,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -6,7 +6,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/packages/heyauthn/package.json
+++ b/packages/heyauthn/package.json
@@ -6,7 +6,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -6,7 +6,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -6,7 +6,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.node.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [


### PR DESCRIPTION
## Description

Fix typescript exports.

This makes it easy to install and `import` from `@semaphore-protocol/*` in a latest-version/default-configuration Typescript project.

## Related Issue

Importing `@semaphore/<x>` in a Node 20 Typescript project currently fails with the following error:

<img width="1008" alt="image" src="https://github.com/semaphore-protocol/semaphore/assets/169280/c9bac928-2a13-4216-8bad-9c92ddfa8402">

This appears to be because Typescript is looking for `package.json` > `"exports"` > `"types"`.


## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
