### PR TITLE
Static height for project `Grid`

### DIFF
--- a/apps/website/src/components/ProjectsList.tsx
+++ b/apps/website/src/components/ProjectsList.tsx
@@ -84,9 +84,14 @@ export default function ProjectsList(props: any) {
                 </HStack>
             </VStack>
 
-            <Grid templateColumns={{ base: "1fr", lg: "repeat(2, 1fr)", "2xl": "repeat(3, 1fr)" }} gap={6}>
+            <Grid
+                templateColumns={{ base: "1fr", lg: "repeat(2, 1fr)", "2xl": "repeat(3, 1fr)" }}
+                gap={4}
+                h="50vh"
+                overflowY="auto"
+            >
                 {projects[index].map((project) => (
-                    <GridItem key={project.name}>
+                    <GridItem key={project.name} maxHeight="25vh">
                         <ProjectCard
                             title={project.name}
                             description={project.tagline}

--- a/apps/website/src/components/ProjectsList.tsx
+++ b/apps/website/src/components/ProjectsList.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Button, Grid, GridItem, HStack, IconButton, Text, VStack } from "@chakra-ui/react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import ProjectCard from "../components/ProjectCard"
 import allProjects from "../data/projects.json"
 import IconChevronLeft from "../icons/IconChevronLeft"
@@ -16,6 +16,7 @@ export default function ProjectsList(props: any) {
     const [index, setIndex] = useState<number>(0)
     const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
     const [onlyPSE, setOnlyPSE] = useState<boolean | null>(null)
+    const viewToScrollRef = useRef<HTMLDivElement>(null)
 
     const filterProjects = useCallback(() => {
         let filteredProjects = allProjects
@@ -38,6 +39,12 @@ export default function ProjectsList(props: any) {
     useEffect(() => {
         filterProjects()
     }, [selectedCategory, onlyPSE])
+
+    useEffect(() => {
+        if (viewToScrollRef.current) {
+            viewToScrollRef.current.scrollIntoView({ behavior: "smooth" })
+        }
+    }, [index])
 
     return (
         <VStack {...props}>
@@ -66,9 +73,8 @@ export default function ProjectsList(props: any) {
                 </HStack>
             </VStack>
 
-            <VStack align="left" spacing="6">
+            <VStack align="left" spacing="6" ref={viewToScrollRef}>
                 <Text fontSize="20">Category</Text>
-
                 <HStack spacing="3" flexWrap="wrap">
                     {getProjectCategories(allProjects).map((category) => (
                         <Button
@@ -84,12 +90,7 @@ export default function ProjectsList(props: any) {
                 </HStack>
             </VStack>
 
-            <Grid
-                templateColumns={{ base: "1fr", lg: "repeat(2, 1fr)", "2xl": "repeat(3, 1fr)" }}
-                gap={4}
-                h="35vh"
-                overflowY="auto"
-            >
+            <Grid templateColumns={{ base: "1fr", lg: "repeat(2, 1fr)", "2xl": "repeat(3, 1fr)" }} gap={6}>
                 {projects[index].map((project) => (
                     <GridItem key={project.name}>
                         <ProjectCard

--- a/apps/website/src/components/ProjectsList.tsx
+++ b/apps/website/src/components/ProjectsList.tsx
@@ -87,11 +87,11 @@ export default function ProjectsList(props: any) {
             <Grid
                 templateColumns={{ base: "1fr", lg: "repeat(2, 1fr)", "2xl": "repeat(3, 1fr)" }}
                 gap={4}
-                h="50vh"
+                h="35vh"
                 overflowY="auto"
             >
                 {projects[index].map((project) => (
-                    <GridItem key={project.name} maxHeight="25vh">
+                    <GridItem key={project.name}>
                         <ProjectCard
                             title={project.name}
                             description={project.tagline}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

To prevent the grid from floating up when the number of projects per page on the grid is less than the maximum, a static grid and grid item height can help prevent this behaviour.

## Related Issue

See #447 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
[Screencast from 12-12-2023 00:26:20.webm](https://github.com/semaphore-protocol/semaphore/assets/20580910/4a8028ce-50bc-4b4c-8742-8694e68df65b)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
