### PR TITLE
Fix Tab selectors on smaller screens

### DIFF
--- a/apps/website/src/app/learn/page.tsx
+++ b/apps/website/src/app/learn/page.tsx
@@ -290,17 +290,16 @@ await verifyProof(verificationKey, fullProof)`,
                     mt={{ base: "100px", md: "170px" }}
                     mb={{ base: "50px", md: "112px" }}
                 >
-                    <Box overflow="auto" mx="3">
-                        <TabList gap="40px" w="max-content" whiteSpace="nowrap">
-                            <Tab px={0} fontSize="24px">
+                    <Box mx="3" overflowX={{ base: "auto", md: "hidden" }}>
+                        <TabList gap="40px" w={{ base: "150%", md: "max-content" }} whiteSpace="nowrap" pl="4">
+                            <Tab px={0} fontSize="24px" _selected={{ borderBottom: "2px solid white" }}>
                                 About Semaphore
                             </Tab>
-                            <Tab px={0} fontSize="24px">
+                            <Tab px={0} fontSize="24px" _selected={{ borderBottom: "2px solid white" }}>
                                 About Zero Knowledge
                             </Tab>
                         </TabList>
                     </Box>
-                    <TabIndicator mt="-1.5px" height="2px" bg="white" borderRadius="1px" />
                     <TabPanels mt="80px">
                         <TabPanel>{renderTabBlockSemaphore()}</TabPanel>
                         <TabPanel>{renderTabBlockZeroKnowledge()}</TabPanel>

--- a/apps/website/src/app/learn/page.tsx
+++ b/apps/website/src/app/learn/page.tsx
@@ -8,7 +8,6 @@ import {
     TabPanels,
     Tab,
     TabPanel,
-    TabIndicator,
     Divider,
     Box,
     Image
@@ -290,8 +289,8 @@ await verifyProof(verificationKey, fullProof)`,
                     mt={{ base: "100px", md: "170px" }}
                     mb={{ base: "50px", md: "112px" }}
                 >
-                    <Box mx="3" overflowX={{ base: "auto", md: "hidden" }}>
-                        <TabList gap="40px" w={{ base: "150%", md: "max-content" }} whiteSpace="nowrap" pl="4">
+                    <Box overflow="auto" mx="3">
+                        <TabList gap="40px" w="max-content" whiteSpace="nowrap">
                             <Tab px={0} fontSize="24px" _selected={{ borderBottom: "2px solid white" }}>
                                 About Semaphore
                             </Tab>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR aims to solve the problem by adding a dynamic `overflowX` and removing the `<TabIndicator>` and replicating its aesthetic behaviour with a `borderBottom` by styling the Tab when selected.

## Related Issue
See #460 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
[Screencast from 12-12-2023 10:57:14.webm](https://github.com/semaphore-protocol/semaphore/assets/20580910/42a920c2-5632-414d-be25-21ed26829f8d)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
