### PR TITLE
Add external references to Poseidon and EdDSA in the `identity` package README

### DIFF
--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -49,8 +49,8 @@
     </h4>
 </div>
 
-| This library provides a class that can be used to create identities compatible with the Semaphore [circuits](https://github.com/semaphore-protocol/semaphore/tree/main/circuits). Each identity contains an EdDSA private key, its public key, and the identity commitment, which is the Poseidon hash of the public key. |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| This library provides a class that can be used to create identities compatible with the Semaphore [circuits](https://github.com/semaphore-protocol/semaphore/tree/main/circuits). Each identity contains an [EdDSA](https://www.rfc-editor.org/rfc/rfc8032) private key, its public key, and the identity commitment, which is the [Poseidon](https://eprint.iacr.org/2019/458.pdf) hash of the public key. |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 ## 🛠 Install
 


### PR DESCRIPTION
## Related Issue
See #534 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
