### PR TITLE
Reflect missing PRs on website after porting documentation to `semaphore` repository

### DIFF
--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/fetching-data.mdx
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/fetching-data.mdx
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem"
 
 # Semaphore data
 
-Para obtener datos on-chain del contrato [Semaphore.sol](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/contracts/Semaphore.sol), puedes usar la librería [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data). 
+Para obtener datos on-chain del contrato [Semaphore.sol](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/contracts/Semaphore.sol), puedes usar la librería [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data).
 
 Hay dos formas para hacer esto, usando [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) o [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts). La clase `SemaphoreSubgraph` usa el [subgrafo de Semaphore](https://github.com/semaphore-protocol/subgraph), el cual usa [The Graph Protocol](https://thegraph.com/) detrás del telón, y la clase `SemaphoreEthers` usa [Ethers](https://github.com/ethers-io/ethers.js/).
 
@@ -23,6 +23,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -38,11 +39,18 @@ yarn add @semaphore-protocol/data
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/data
+```
+
+</TabItem>
 </Tabs>
 
 ## Obtener datos usando SemaphoreSubgraph
 
-Para obtener datos usando el subgrafo de Semaphore puedes usar la clase [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) del paquete [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data). 
+Para obtener datos usando el subgrafo de Semaphore puedes usar la clase [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) del paquete [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data).
 
 ```typescript
 import { SemaphoreSubgraph } from "@semaphore-protocol/data"
@@ -109,7 +117,7 @@ const group = new Group(groupId, 20, members)
 
 ## Obtener datos usando SemaphoreEthers
 
-Para obtener datos usando Ethers puedes usar la clase [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts) del paquete [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data). 
+Para obtener datos usando Ethers puedes usar la clase [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts) del paquete [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data).
 
 ```typescript
 import { SemaphoreEthers } from "@semaphore-protocol/data"

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/groups.mdx
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/groups.mdx
@@ -39,7 +39,7 @@ Utilice la clase `Group` de la librería [`@semaphore-protocol/group`](https://g
 
 -   `Group id`: un identificar único para el grupo;
 -   `Tree depth`: (_default `20`_) el número máximo de usuarios que puede contener un grupo, el valor por defecto es 20 (`max size = 2 ^ tree depth`).
--   `Members`: (_default `[]`_) la lista de miembros para inicializar el grupo. 
+-   `Members`: (_default `[]`_) la lista de miembros para inicializar el grupo.
 
 #### Instalar librería:
 
@@ -49,6 +49,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -61,6 +62,13 @@ npm install @semaphore-protocol/group
 
 ```bash
 yarn add @semaphore-protocol/group
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/group
 ```
 
 </TabItem>

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/identities.mdx
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/identities.mdx
@@ -32,18 +32,24 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
 ```bash
 npm install @semaphore-protocol/identity
 ```
-
 </TabItem>
 <TabItem value="yarn">
-
 ```bash
 yarn add @semaphore-protocol/identity
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/identity
 ```
 
 </TabItem>

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/proofs.mdx
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/proofs.mdx
@@ -38,6 +38,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -50,6 +51,12 @@ npm install @semaphore-protocol/proof
 
 ```bash
 yarn add @semaphore-protocol/proof
+```
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/proof
 ```
 
 </TabItem>

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/quick-setup.mdx
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/quick-setup.mdx
@@ -36,6 +36,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -51,6 +52,14 @@ npm i
 cd my-app
 yarn
 ```
+</TabItem>
+
+<TabItem value="pnpm">
+
+```bash
+cd my-app
+pnpm install
+```
 
 </TabItem>
 </Tabs>
@@ -63,21 +72,21 @@ El comando `create` creará un directorio con el nombre my-app (o cualquier nomb
 my-app
 ├── .yarn
 ├── apps
-│   └── contracts
-│   │   └── contracts
-|   │   │   └── Feedback.sol
-│   │   └── scripts
-|   │   │   └── download-snark-artifacts.ts
-│   │   └── tasks
-|   │   │   └── deploy.ts
-│   │   └── test
-|   │   │   └── Feedback.ts
-│   │   └── hardhat.config.ts
-│   │   └── package.json
-│   │   └── tsconfig.json
-│   └── web-app
+│   └── contracts
+│   │   └── contracts
+|   │   │   └── Feedback.sol
+│   │   └── scripts
+|   │   │   └── download-snark-artifacts.ts
+│   │   └── tasks
+|   │   │   └── deploy.ts
+│   │   └── test
+|   │   │   └── Feedback.ts
+│   │   └── hardhat.config.ts
+│   │   └── package.json
+│   │   └── tsconfig.json
+│   └── web-app
 ├── scripts
-│   └── copy-contracts-artifacts.ts
+│   └── copy-contracts-artifacts.ts
 ├── .editorconfig
 ├── .env
 ├── .env.example
@@ -112,6 +121,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -127,6 +137,13 @@ yarn compile
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm compile
+```
+
+</TabItem>
 </Tabs>
 
 ### Pruebe los contratos
@@ -139,6 +156,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -154,6 +172,13 @@ yarn test
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test
+```
+
+</TabItem>
 </Tabs>
 
 Genere un reporte de la prueba de cobertura:
@@ -164,6 +189,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -179,6 +205,13 @@ yarn test:coverage
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test:coverage
+```
+
+</TabItem>
 </Tabs>
 
 O un reporte de la prueba de gas:
@@ -189,6 +222,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -201,6 +235,13 @@ npm run test:report-gas
 
 ```bash
 yarn test:report-gas
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test:report-gas
 ```
 
 </TabItem>
@@ -226,6 +267,7 @@ En la carpeta raíz del proyecto:
     values={[
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
+    {label: 'pnpm', value: 'pnpm'}
     ]}>
     <TabItem value="npm">
 
@@ -238,6 +280,13 @@ En la carpeta raíz del proyecto:
 
     ```bash
     yarn deploy --semaphore <semaphore-address> --group <group-id> --network goerli
+    ```
+
+    </TabItem>
+    <TabItem value="pnpm">
+
+    ```bash
+    pnpm deploy --semaphore <semaphore-address> --group <group-id> --network goerli
     ```
 
     </TabItem>
@@ -261,6 +310,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -273,6 +323,13 @@ npm run dev
 
 ```bash
 yarn dev
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm dev
 ```
 
 </TabItem>

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/troubleshooting.mdx
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V3/troubleshooting.mdx
@@ -75,6 +75,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -90,6 +91,13 @@ yarn add @esbuild-plugins/node-globals-polyfill
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @esbuild-plugins/node-globals-polyfill
+```
+
+</TabItem>
 </Tabs>
 
 <Tabs
@@ -98,6 +106,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -110,6 +119,13 @@ npm install @esbuild-plugins/node-modules-polyfill
 
 ```bash
 yarn add @esbuild-plugins/node-modules-polyfill
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @esbuild-plugins/node-modules-polyfill
 ```
 
 </TabItem>

--- a/apps/docs/versioned_docs/version-V3/guides/fetching-data.mdx
+++ b/apps/docs/versioned_docs/version-V3/guides/fetching-data.mdx
@@ -131,7 +131,7 @@ const semaphoreEthers = new SemaphoreEthers("homestead", {
 })
 
 // or:
-const semaphoreEthers = new SemaphoreEthers("http://localhost:8545", {
+const semaphoreEthers = new SemaphoreEthers("http://127.0.0.1:8545", {
     address: "semaphore-address"
 })
 ```

--- a/apps/docs/versioned_docs/version-V3/guides/fetching-data.mdx
+++ b/apps/docs/versioned_docs/version-V3/guides/fetching-data.mdx
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem"
 
 # Semaphore data
 
-To fetch on-chain data from the [Semaphore.sol](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/contracts/Semaphore.sol) contract, you can use the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) library. 
+To fetch on-chain data from the [Semaphore.sol](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/contracts/Semaphore.sol) contract, you can use the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) library.
 
 There are two ways to do this, using [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) or [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts). The `SemaphoreSubgraph` class uses the [Semaphore subgraph](https://github.com/semaphore-protocol/subgraph), which uses [The Graph Protocol](https://thegraph.com/) under the hood, and the `SemaphoreEthers` class uses [Ethers](https://github.com/ethers-io/ethers.js/).
 
@@ -23,6 +23,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -38,11 +39,18 @@ yarn add @semaphore-protocol/data
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/data
+```
+
+</TabItem>
 </Tabs>
 
 ## Fetch data using SemaphoreSubgraph
 
-To fetch data using the Semaphore subgraph you can use the [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) class from the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) package. 
+To fetch data using the Semaphore subgraph you can use the [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) class from the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) package.
 
 ```typescript
 import { SemaphoreSubgraph } from "@semaphore-protocol/data"
@@ -109,7 +117,7 @@ const group = new Group(groupId, 20, members)
 
 ## Fetch data using SemaphoreEthers
 
-To fetch data using Ethers you can use the [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts) class from the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) package. 
+To fetch data using Ethers you can use the [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts) class from the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) package.
 
 ```typescript
 import { SemaphoreEthers } from "@semaphore-protocol/data"

--- a/apps/docs/versioned_docs/version-V3/guides/groups.mdx
+++ b/apps/docs/versioned_docs/version-V3/guides/groups.mdx
@@ -39,7 +39,7 @@ Use the [`@semaphore-protocol/group`](https://github.com/semaphore-protocol/sema
 
 -   `Group id`: a unique identifier for the group;
 -   `Tree depth`: (_default `20`_) the maximum number of members a group can contain (`max size = 2 ^ tree depth`).
--   `Members`: (_default `[]`_) the list of members to initialize the group. 
+-   `Members`: (_default `[]`_) the list of members to initialize the group.
 
 #### Install library:
 
@@ -49,6 +49,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -61,6 +62,13 @@ npm install @semaphore-protocol/group
 
 ```bash
 yarn add @semaphore-protocol/group
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/group
 ```
 
 </TabItem>

--- a/apps/docs/versioned_docs/version-V3/guides/identities.mdx
+++ b/apps/docs/versioned_docs/version-V3/guides/identities.mdx
@@ -32,6 +32,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -44,6 +45,13 @@ npm install @semaphore-protocol/identity
 
 ```bash
 yarn add @semaphore-protocol/identity
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/identity
 ```
 
 </TabItem>

--- a/apps/docs/versioned_docs/version-V3/guides/proofs.mdx
+++ b/apps/docs/versioned_docs/version-V3/guides/proofs.mdx
@@ -38,6 +38,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -50,6 +51,13 @@ npm install @semaphore-protocol/proof
 
 ```bash
 yarn add @semaphore-protocol/proof
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/proof
 ```
 
 </TabItem>

--- a/apps/docs/versioned_docs/version-V3/quick-setup.mdx
+++ b/apps/docs/versioned_docs/version-V3/quick-setup.mdx
@@ -36,6 +36,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -53,6 +54,14 @@ yarn
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+cd my-app
+pnpm install
+```
+
+</TabItem>
 </Tabs>
 
 ## Output
@@ -63,21 +72,21 @@ The `create` command will create a directory called my-app (or whatever name you
 my-app
 ├── .yarn
 ├── apps
-│   └── contracts
-│   │   └── contracts
-|   │   │   └── Feedback.sol
-│   │   └── scripts
-|   │   │   └── download-snark-artifacts.ts
-│   │   └── tasks
-|   │   │   └── deploy.ts
-│   │   └── test
-|   │   │   └── Feedback.ts
-│   │   └── hardhat.config.ts
-│   │   └── package.json
-│   │   └── tsconfig.json
-│   └── web-app
+│   └── contracts
+│   │   └── contracts
+|   │   │   └── Feedback.sol
+│   │   └── scripts
+|   │   │   └── download-snark-artifacts.ts
+│   │   └── tasks
+|   │   │   └── deploy.ts
+│   │   └── test
+|   │   │   └── Feedback.ts
+│   │   └── hardhat.config.ts
+│   │   └── package.json
+│   │   └── tsconfig.json
+│   └── web-app
 ├── scripts
-│   └── copy-contracts-artifacts.ts
+│   └── copy-contracts-artifacts.ts
 ├── .editorconfig
 ├── .env
 ├── .env.example
@@ -92,7 +101,7 @@ my-app
 └── tsconfig.json
 ```
 
-The `Feedback.sol` contract creates a Semaphore group, allows users to join that group with their Semaphore identity, and finally allows group members to send an anonymous feedback. 
+The `Feedback.sol` contract creates a Semaphore group, allows users to join that group with their Semaphore identity, and finally allows group members to send an anonymous feedback.
 
 ## Usage
 
@@ -112,6 +121,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -127,6 +137,13 @@ yarn compile
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm compile
+```
+
+</TabItem>
 </Tabs>
 
 ### Test contracts
@@ -139,6 +156,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -154,6 +172,13 @@ yarn test
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test
+```
+
+</TabItem>
 </Tabs>
 
 Generate a test coverage report:
@@ -164,6 +189,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -179,6 +205,13 @@ yarn test:coverage
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test:coverage
+```
+
+</TabItem>
 </Tabs>
 
 Or a test gas report:
@@ -189,6 +222,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -201,6 +235,13 @@ npm run test:report-gas
 
 ```bash
 yarn test:report-gas
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test:report-gas
 ```
 
 </TabItem>
@@ -226,6 +267,7 @@ In the project root folder:
     values={[
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
+    {label: 'pnpm', value: 'pnpm'}
     ]}>
     <TabItem value="npm">
 
@@ -238,6 +280,13 @@ In the project root folder:
 
     ```bash
     yarn deploy --semaphore <semaphore-address> --group <group-id> --network arbitrum-goerli
+    ```
+
+    </TabItem>
+    <TabItem value="pnpm">
+
+    ```bash
+    pnpm deploy --semaphore <semaphore-address> --group <group-id> --network arbitrum-goerli
     ```
 
     </TabItem>
@@ -261,6 +310,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -273,6 +323,13 @@ npm run dev
 
 ```bash
 yarn dev
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm dev
 ```
 
 </TabItem>

--- a/apps/docs/versioned_docs/version-V3/resources.md
+++ b/apps/docs/versioned_docs/version-V3/resources.md
@@ -12,6 +12,8 @@ sidebar_position: 9
 
 [Semaphore V2 is Live!](https://medium.com/privacy-scaling-explorations/semaphore-v2-is-live-f263e9372579) - Privacy and Scaling Explorations
 
+[Zero-Knowledge Group Membership Management With Semaphore](https://medium.com/javascript-in-plain-english/zero-knowledge-group-membership-management-with-the-semaphore-protocol-1a63126de81c) - Laszlo Fazekas
+
 ## Videos
 
 [Privacy in Ethereum](https://www.youtube.com/watch?v=maDHYyj30kg) - Barry WhiteHat at the Taipei Ethereum Meetup

--- a/apps/docs/versioned_docs/version-V3/troubleshooting.mdx
+++ b/apps/docs/versioned_docs/version-V3/troubleshooting.mdx
@@ -75,6 +75,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -90,6 +91,13 @@ yarn add @esbuild-plugins/node-globals-polyfill
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @esbuild-plugins/node-globals-polyfill
+```
+
+</TabItem>
 </Tabs>
 
 <Tabs
@@ -98,6 +106,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -110,6 +119,13 @@ npm install @esbuild-plugins/node-modules-polyfill
 
 ```bash
 yarn add @esbuild-plugins/node-modules-polyfill
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @esbuild-plugins/node-modules-polyfill
 ```
 
 </TabItem>


### PR DESCRIPTION
:warning: The PRs are the following (and not the ones automatically linked by GH in the commits)!!!

- https://github.com/semaphore-protocol/website/pull/110
- https://github.com/semaphore-protocol/website/pull/111
- https://github.com/semaphore-protocol/website/pull/113

## Related Issue
See https://github.com/semaphore-protocol/semaphore/issues/526
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
