### PR TITLE
Chore/change cli create message

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -98,7 +98,7 @@ program
         console.info(`\n ${logSymbols.success}`, `Your project is ready!\n`)
         console.info(` Please, install your dependencies by running:\n`)
         console.info(`   ${chalk.cyan("cd")} ${projectDirectory}`)
-        console.info(`   ${chalk.cyan("npm i")}\n`)
+        console.info(`   ${chalk.cyan("yarn install")}\n`)
 
         const { scripts } = JSON.parse(readFileSync(`${currentDirectory}/${projectDirectory}/package.json`, "utf8"))
 
@@ -107,7 +107,7 @@ program
 
             console.info(
                 `${Object.keys(scripts)
-                    .map((s) => `   ${chalk.cyan(`npm run ${s}`)}`)
+                    .map((s) => `   ${chalk.cyan(`yarn ${s}`)}`)
                     .join("\n")}\n`
             )
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes the message that gets logged when running the CLI `create` command to reference Yarn instead of NPM. 


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #592 
## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

![image](https://github.com/semaphore-protocol/semaphore/assets/22231097/7538792c-993c-4309-abd4-c8be4bb69646)
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
