### PR TITLE
Set correct DMSans font URL

### DIFF
--- a/apps/docs/src/css/custom.scss
+++ b/apps/docs/src/css/custom.scss
@@ -7,7 +7,7 @@
 /* You can override the default Infima variables here. */
 
 @import url("https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=DMSans:wght@400;500;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&display=swap");
 
 :root {
     --ifm-color-primary: "linear(to-r, #4771ea, #2735a6)";


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

The Google DMSans URL was wrong and didn't find the right `font-face` properties, causing problems in some browsers.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
