### PR TITLE
Empty group roots are "0" instead of undefined

### DIFF
--- a/packages/group/src/group.ts
+++ b/packages/group/src/group.ts
@@ -17,8 +17,8 @@ export default class Group {
      * Returns the root hash of the tree.
      * @returns Root hash.
      */
-    get root(): string | undefined {
-        return this.leanIMT.root?.toString()
+    get root(): string {
+        return this.leanIMT.root ? this.leanIMT.root.toString() : "0"
     }
 
     /**

--- a/packages/group/tests/index.test.ts
+++ b/packages/group/tests/index.test.ts
@@ -5,7 +5,7 @@ describe("Group", () => {
         it("Should create a group", () => {
             const group = new Group()
 
-            expect(group.root).toBeUndefined()
+            expect(group.root).toBe("0")
             expect(group.depth).toBe(0)
             expect(group.size).toBe(0)
         })


### PR DESCRIPTION
## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #620 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
