### PR TITLE
Support of `message`/`scope` as strings

### DIFF
--- a/packages/cli-template-monorepo-ethers/apps/contracts/test/Feedback.ts
+++ b/packages/cli-template-monorepo-ethers/apps/contracts/test/Feedback.ts
@@ -1,6 +1,5 @@
 import { Group, Identity, generateProof } from "@semaphore-protocol/core"
 import { expect } from "chai"
-import { encodeBytes32String } from "ethers"
 import { run } from "hardhat"
 // @ts-ignore: typechain folder will be generated after contracts compilation
 import { Feedback } from "../typechain-types"
@@ -41,7 +40,7 @@ describe("Feedback", () => {
 
     describe("# sendFeedback", () => {
         it("Should allow users to send feedback anonymously", async () => {
-            const feedback = encodeBytes32String("Hello World")
+            const feedback = "Hello World"
 
             const proof = await generateProof(users[1], group, feedback, groupId)
 
@@ -49,7 +48,7 @@ describe("Feedback", () => {
                 proof.merkleTreeDepth,
                 proof.merkleTreeRoot,
                 proof.nullifier,
-                feedback,
+                proof.message,
                 proof.points
             )
 

--- a/packages/cli-template-monorepo-ethers/apps/web-app/src/pages/proofs.tsx
+++ b/packages/cli-template-monorepo-ethers/apps/web-app/src/pages/proofs.tsx
@@ -1,5 +1,4 @@
 import { Group, Identity, generateProof } from "@semaphore-protocol/core"
-import { encodeBytes32String } from "ethers"
 import getNextConfig from "next/config"
 import { useRouter } from "next/router"
 import { useCallback, useContext, useEffect, useState } from "react"
@@ -54,12 +53,10 @@ export default function ProofsPage() {
             try {
                 const group = new Group(_users)
 
-                const message = encodeBytes32String(feedback)
-
-                const { points, merkleTreeDepth, merkleTreeRoot, nullifier } = await generateProof(
+                const { points, merkleTreeDepth, merkleTreeRoot, nullifier, message } = await generateProof(
                     _identity,
                     group,
-                    message,
+                    feedback,
                     env.GROUP_ID
                 )
 

--- a/packages/cli-template-monorepo-subgraph/apps/contracts/test/Feedback.ts
+++ b/packages/cli-template-monorepo-subgraph/apps/contracts/test/Feedback.ts
@@ -1,6 +1,5 @@
 import { Group, Identity, generateProof } from "@semaphore-protocol/core"
 import { expect } from "chai"
-import { encodeBytes32String } from "ethers"
 import { run } from "hardhat"
 // @ts-ignore: typechain folder will be generated after contracts compilation
 import { Feedback } from "../typechain-types"
@@ -41,7 +40,7 @@ describe("Feedback", () => {
 
     describe("# sendFeedback", () => {
         it("Should allow users to send feedback anonymously", async () => {
-            const feedback = encodeBytes32String("Hello World")
+            const feedback = "Hello World"
 
             const proof = await generateProof(users[1], group, feedback, groupId)
 
@@ -49,7 +48,7 @@ describe("Feedback", () => {
                 proof.merkleTreeDepth,
                 proof.merkleTreeRoot,
                 proof.nullifier,
-                feedback,
+                proof.message,
                 proof.points
             )
 

--- a/packages/cli-template-monorepo-subgraph/apps/web-app/src/pages/proofs.tsx
+++ b/packages/cli-template-monorepo-subgraph/apps/web-app/src/pages/proofs.tsx
@@ -1,5 +1,4 @@
 import { Group, Identity, generateProof } from "@semaphore-protocol/core"
-import { encodeBytes32String } from "ethers"
 import getNextConfig from "next/config"
 import { useRouter } from "next/router"
 import { useCallback, useContext, useEffect, useState } from "react"
@@ -54,12 +53,10 @@ export default function ProofsPage() {
             try {
                 const group = new Group(_users)
 
-                const message = encodeBytes32String(feedback)
-
-                const { points, merkleTreeDepth, merkleTreeRoot, nullifier } = await generateProof(
+                const { points, merkleTreeDepth, merkleTreeRoot, nullifier, message } = await generateProof(
                     _identity,
                     group,
-                    message,
+                    feedback,
                     env.GROUP_ID
                 )
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -72,7 +72,6 @@ yarn add @semaphore-protocol/core
 
 ```typescript
 import { Identity, Group, generateProof, verifyProof } from "@semaphore-protocol/core"
-import { utils } from "ethers"
 
 const identity1 = new Identity()
 const identity2 = new Identity()
@@ -80,8 +79,8 @@ const identity3 = new Identity()
 
 const group = new Group([identity1.commitment, identity2.commitment, identity3.commitment])
 
-const scope = utils.formatBytes32String("Semaphore")
-const message = utils.formatBytes32String("Hello world")
+const message = "Hello world"
+const scope = "Semaphore"
 
 const proof = await generateProof(identity1, group, message, scope)
 

--- a/packages/proof/README.md
+++ b/packages/proof/README.md
@@ -73,8 +73,8 @@ yarn add @semaphore-protocol/identity @semaphore-protocol/group @semaphore-proto
 \# **generateProof**(
 identity: _Identity_,
 group: _Group_,
-message: _BytesLike | Hexable | number | bigint_,
-scope: _BytesLike | Hexable | number | bigint_,
+message: _BigNumberish_ | _Uint8Array_ | string,
+scope: _BigNumberish_ | _Uint8Array_ | string,
 merkleTreeDepth: _number_,
 snarkArtifacts?: _SnarkArtifacts_
 ): Promise\<_SemaphoreProof_>
@@ -83,23 +83,23 @@ snarkArtifacts?: _SnarkArtifacts_
 import { Identity } from "@semaphore-protocol/identity"
 import { Group } from "@semaphore-protocol/group"
 import { generateProof } from "@semaphore-protocol/proof"
-import { utils } from "ethers"
 
-const identity = new Identity()
-const group = new Group()
+const identity1 = new Identity()
+const identity2 = new Identity()
+const identity3 = new Identity()
 
-const scope = utils.formatBytes32String("Topic")
-const message = utils.formatBytes32String("Hello world")
+const group = new Group([identity1.commitment, identity2.commitment, identity3.commitment])
 
-group.addMembers([...identityCommitments, identity.generateCommitment()])
+const message = "Hello world"
+const scope = "Semaphore"
 
-const proof1 = await generateProof(identity, group, message, scope)
+const proof1 = await generateProof(identity1, group, message, scope)
 
 // You can also specify the maximum tree depth supported by the proof.
-const proof2 = await generateProof(identity, group, message, scope, 20)
+const proof2 = await generateProof(identity2, group, message, scope, 20)
 
 // You can also specify the default zkey/wasm files.
-const proof3 = await generateProof(identity, group, message, scope, 20, {
+const proof3 = await generateProof(identity3, group, message, scope, 20, {
     wasmFilePath: "./semaphore.wasm",
     zkeyFilePath: "./semaphore.zkey"
 })

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -54,11 +54,9 @@
         "@semaphore-protocol/identity": "4.0.0-alpha.6"
     },
     "dependencies": {
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
         "@types/snarkjs": "0.7.8",
         "download": "8.0.0",
+        "ethers": "6.10.0",
         "snarkjs": "0.7.3",
         "tmp": "0.2.1"
     }

--- a/packages/proof/src/generate-proof.ts
+++ b/packages/proof/src/generate-proof.ts
@@ -11,8 +11,8 @@ import { BigNumberish, SemaphoreProof, SnarkArtifacts } from "./types"
  * Generates a Semaphore proof.
  * @param identity The Semaphore identity.
  * @param groupOrMerkleProof The Semaphore group or its Merkle proof.
- * @param scope The external nullifier.
- * @param message The Semaphore signal.
+ * @param scope The Semaphore scope.
+ * @param message The Semaphore message.
  * @param merkleTreeDepth The depth of the tree with which the circuit was compiled.
  * @param snarkArtifacts The SNARK artifacts.
  * @returns The Semaphore proof ready to be verified.
@@ -20,8 +20,8 @@ import { BigNumberish, SemaphoreProof, SnarkArtifacts } from "./types"
 export default async function generateProof(
     identity: Identity,
     groupOrMerkleProof: Group | MerkleProof,
-    message: BigNumberish | Uint8Array,
-    scope: BigNumberish | Uint8Array,
+    message: BigNumberish | Uint8Array | string,
+    scope: BigNumberish | Uint8Array | string,
     merkleTreeDepth?: number,
     snarkArtifacts?: SnarkArtifacts
 ): Promise<SemaphoreProof> {

--- a/packages/proof/src/generate-proof.ts
+++ b/packages/proof/src/generate-proof.ts
@@ -1,11 +1,11 @@
 import type { Group, MerkleProof } from "@semaphore-protocol/group"
 import type { Identity } from "@semaphore-protocol/identity"
-import { encodeBytes32String, toBigInt } from "ethers"
 import { NumericString, groth16 } from "snarkjs"
 import getSnarkArtifacts from "./get-snark-artifacts.node"
 import hash from "./hash"
 import packPoints from "./pack-points"
 import { BigNumberish, SemaphoreProof, SnarkArtifacts } from "./types"
+import toBigInt from "./to-bigint"
 
 /**
  * Generates a Semaphore proof.
@@ -25,25 +25,8 @@ export default async function generateProof(
     merkleTreeDepth?: number,
     snarkArtifacts?: SnarkArtifacts
 ): Promise<SemaphoreProof> {
-    try {
-        message = toBigInt(message)
-    } catch (error: any) {
-        if (typeof message === "string") {
-            message = encodeBytes32String(message)
-        } else {
-            throw TypeError(error.message)
-        }
-    }
-
-    try {
-        scope = toBigInt(scope)
-    } catch (error: any) {
-        if (typeof scope === "string") {
-            scope = encodeBytes32String(scope)
-        } else {
-            throw TypeError(error.message)
-        }
-    }
+    message = toBigInt(message)
+    scope = toBigInt(scope)
 
     let merkleProof
 

--- a/packages/proof/src/hash.ts
+++ b/packages/proof/src/hash.ts
@@ -1,16 +1,12 @@
-import { BigNumber } from "@ethersproject/bignumber"
-import { BytesLike, Hexable, zeroPad } from "@ethersproject/bytes"
-import { keccak256 } from "@ethersproject/keccak256"
+import { keccak256, toBeHex } from "ethers"
 import { NumericString } from "snarkjs"
+import { BigNumberish } from "./types"
 
 /**
  * Creates a keccak256 hash of a message compatible with the SNARK scalar modulus.
  * @param message The message to be hashed.
  * @returns The message digest.
  */
-export default function hash(message: BytesLike | Hexable | number | bigint): NumericString {
-    message = BigNumber.from(message).toTwos(256).toHexString()
-    message = zeroPad(message, 32)
-
-    return (BigInt(keccak256(message)) >> BigInt(8)).toString() as NumericString
+export default function hash(message: BigNumberish): NumericString {
+    return (BigInt(keccak256(toBeHex(message, 32))) >> BigInt(8)).toString()
 }

--- a/packages/proof/src/to-bigint.ts
+++ b/packages/proof/src/to-bigint.ts
@@ -1,0 +1,14 @@
+import { encodeBytes32String, toBigInt as _toBigInt } from "ethers"
+import { BigNumberish } from "./types"
+
+export default function toBigInt(value: BigNumberish | Uint8Array | string): bigint {
+    try {
+        return _toBigInt(value)
+    } catch (error: any) {
+        if (typeof value === "string") {
+            return _toBigInt(encodeBytes32String(value))
+        }
+
+        throw TypeError(error.message)
+    }
+}

--- a/packages/proof/tests/index.test.ts
+++ b/packages/proof/tests/index.test.ts
@@ -1,4 +1,3 @@
-import { formatBytes32String } from "@ethersproject/strings"
 import { Group } from "@semaphore-protocol/group"
 import { Identity } from "@semaphore-protocol/identity"
 import { getCurveFromName } from "ffjavascript"
@@ -7,8 +6,8 @@ import { SemaphoreProof, generateProof, packPoints, unpackPoints, verifyProof } 
 describe("Proof", () => {
     const treeDepth = 10
 
-    const message = formatBytes32String("Hello world")
-    const scope = formatBytes32String("Scope")
+    const message = "Hello world"
+    const scope = "Scope"
 
     const identity = new Identity(42)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8556,9 +8556,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@semaphore-protocol/proof@workspace:packages/proof"
   dependencies:
-    "@ethersproject/bignumber": 5.7.0
-    "@ethersproject/bytes": 5.7.0
-    "@ethersproject/keccak256": 5.7.0
     "@ethersproject/strings": ^5.7.0
     "@rollup/plugin-alias": ^5.1.0
     "@rollup/plugin-json": ^6.1.0
@@ -8566,6 +8563,7 @@ __metadata:
     "@types/snarkjs": 0.7.8
     "@types/tmp": ^0.2.6
     download: 8.0.0
+    ethers: 6.10.0
     poseidon-lite: ^0.2.0
     rimraf: ^5.0.5
     rollup: ^4.0.2


### PR DESCRIPTION
## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #614, #615

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
