### PR TITLE
Adds `getGroupMembers` & `getGroupValidatedProofs` functions to `SemaphoreSubgraph`

### DIFF
--- a/packages/data/src/subgraph.ts
+++ b/packages/data/src/subgraph.ts
@@ -209,7 +209,7 @@ export default class SemaphoreSubgraph {
      */
     async getGroupMembers(groupId: string): Promise<string[]> {
         const group = await this.getGroup(groupId, { members: true }) // parameters are checked inside getGroup
-        return group.members ?? []
+        return group.members!
     }
 
     /**
@@ -219,7 +219,7 @@ export default class SemaphoreSubgraph {
      */
     async getGroupValidatedProofs(groupId: string): Promise<any[]> {
         const group = await this.getGroup(groupId, { validatedProofs: true }) // parameters are checked inside getGroup
-        return group.validatedProofs ?? []
+        return group.validatedProofs!
     }
 
     /**

--- a/packages/data/src/subgraph.ts
+++ b/packages/data/src/subgraph.ts
@@ -203,6 +203,16 @@ export default class SemaphoreSubgraph {
     }
 
     /**
+     * Returns a list of group members.
+     * @param groupId Group id.
+     * @returns Group members.
+     */
+    async getGroupMembers(groupId: string): Promise<string[]> {
+        const group = await this.getGroup(groupId, { members: true }) // parameters are checked inside getGroup
+        return group.members ?? []
+    }
+
+    /**
      * Returns true if a member is part of group, and false otherwise.
      * @param groupId Group id
      * @param member Group member.

--- a/packages/data/src/subgraph.ts
+++ b/packages/data/src/subgraph.ts
@@ -213,6 +213,16 @@ export default class SemaphoreSubgraph {
     }
 
     /**
+     * Returns a list of validated proofs.
+     * @param groupId Group id.
+     * @returns Validated proofs.
+     */
+    async getGroupValidatedProofs(groupId: string): Promise<any[]> {
+        const group = await this.getGroup(groupId, { validatedProofs: true }) // parameters are checked inside getGroup
+        return group.validatedProofs ?? []
+    }
+
+    /**
      * Returns true if a member is part of group, and false otherwise.
      * @param groupId Group id
      * @param member Group member.

--- a/packages/data/tests/subgraph.test.ts
+++ b/packages/data/tests/subgraph.test.ts
@@ -386,6 +386,73 @@ describe("SemaphoreSubgraph", () => {
         })
     })
 
+    describe("# getGroupValidatedProofs", () => {
+        it("Should return a list of group validated proofs", async () => {
+            requestMocked.mockImplementationOnce(() =>
+                Promise.resolve({
+                    groups: [
+                        {
+                            id: "1",
+                            merkleTree: {
+                                depth: 20,
+                                size: 2,
+                                root: "2"
+                            },
+                            admin: "0x7bcd6f009471e9974a77086a69289d16eadba286",
+                            validatedProofs: [
+                                {
+                                    message: "0x3243b",
+                                    merkleTreeRoot: "1332132",
+                                    merkleTreeDepth: "32",
+                                    scope: "14324",
+                                    nullifier: "442342",
+                                    points: ["442342"],
+                                    timestamp: "1657306917"
+                                },
+                                {
+                                    message: "0x5233a",
+                                    merkleTreeRoot: "1332132",
+                                    merkleTreeDepth: "32",
+                                    scope: "14324",
+                                    nullifier: "442342",
+                                    points: ["442342"],
+                                    timestamp: "1657306923"
+                                }
+                            ]
+                        }
+                    ]
+                })
+            )
+            const expectedValue = await semaphore.getGroupValidatedProofs("1")
+
+            expect(expectedValue).toBeDefined()
+            expect(Array.isArray(expectedValue)).toBeTruthy()
+            expect(expectedValue[0]).toEqual({
+                message: "0x3243b",
+                merkleTreeRoot: "1332132",
+                merkleTreeDepth: "32",
+                scope: "14324",
+                nullifier: "442342",
+                points: ["442342"],
+                timestamp: "1657306917"
+            })
+            expect(expectedValue[1]).toEqual({
+                message: "0x5233a",
+                merkleTreeRoot: "1332132",
+                merkleTreeDepth: "32",
+                scope: "14324",
+                nullifier: "442342",
+                points: ["442342"],
+                timestamp: "1657306923"
+            })
+        })
+
+        it("Should throw an error if the groupId parameter type is wrong", async () => {
+            const fun = () => semaphore.getGroupValidatedProofs(1 as any)
+            await expect(fun).rejects.toThrow("Parameter 'groupId' is not a string")
+        })
+    })
+
     describe("# isGroupMember", () => {
         it("Should throw an error if the member parameter type is wrong", async () => {
             const fun = () => semaphore.isGroupMember("1", 1 as any)

--- a/packages/data/tests/subgraph.test.ts
+++ b/packages/data/tests/subgraph.test.ts
@@ -346,6 +346,46 @@ describe("SemaphoreSubgraph", () => {
         })
     })
 
+    describe("# getGroupMembers", () => {
+        it("Should return a list of group members", async () => {
+            requestMocked.mockImplementationOnce(() =>
+                Promise.resolve({
+                    groups: [
+                        {
+                            id: "1",
+                            merkleTree: {
+                                depth: 20,
+                                size: 2,
+                                root: "2"
+                            },
+                            admin: "0x7bcd6f009471e9974a77086a69289d16eadba286",
+                            members: [
+                                {
+                                    identityCommitment: "20"
+                                },
+                                {
+                                    identityCommitment: "17"
+                                }
+                            ]
+                        }
+                    ]
+                })
+            )
+
+            const expectedValue = await semaphore.getGroupMembers("1")
+
+            expect(expectedValue).toBeDefined()
+            expect(Array.isArray(expectedValue)).toBeTruthy()
+            expect(expectedValue[0]).toBe("20")
+            expect(expectedValue[1]).toBe("17")
+        })
+
+        it("Should throw an error if the groupId parameter type is wrong", async () => {
+            const fun = () => semaphore.getGroupMembers(1 as any)
+            await expect(fun).rejects.toThrow("Parameter 'groupId' is not a string")
+        })
+    })
+
     describe("# isGroupMember", () => {
         it("Should throw an error if the member parameter type is wrong", async () => {
             const fun = () => semaphore.isGroupMember("1", 1 as any)


### PR DESCRIPTION
## Related Issue(s)
Closes #619 

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any **new** errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
