### PR TITLE
Add script to remove stableVersion field

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
         "prettier": "prettier -c .",
         "prettier:write": "prettier -w .",
         "docs": "typedoc --cname js.semaphore.pse.dev --githubPages true",
-        "version:bump": "yarn workspaces foreach -A --no-private version -d ${0} && yarn version apply --all && git commit -am \"chore: v${0}\" && git tag v${0}",
+        "version:bump": "yarn workspaces foreach -A --no-private version -d ${0} && yarn version apply --all && yarn remove:stable-version-field && git commit -am \"chore: v${0}\" && git tag v${0}",
         "version:publish": "yarn build:libraries && yarn clean:cli-templates && yarn workspaces foreach -A --no-private npm publish --tolerate-republish --access public",
         "version:release": "changelogithub",
         "clean": "ts-node scripts/clean-apps.ts && ts-node scripts/clean-packages.ts && yarn clean:cli-templates && rimraf node_modules",
         "clean:cli-templates": "ts-node scripts/clean-cli-templates.ts",
+        "remove:stable-version-field": "ts-node scripts/remove-stable-version-field.ts && yarn prettier:write",
         "commit": "cz",
         "precommit": "lint-staged",
         "postinstall": "husky install"

--- a/scripts/clean-apps.ts
+++ b/scripts/clean-apps.ts
@@ -15,11 +15,11 @@ const gitIgnored = [
 ]
 
 async function main() {
-    const apps = readdirSync(folderName, { withFileTypes: true })
+    const folders = readdirSync(folderName, { withFileTypes: true })
         .filter((file) => file.isDirectory())
         .map((dir) => dir.name)
 
-    apps.map((app) => gitIgnored.map((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })))
+    folders.map((app) => gitIgnored.map((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })))
 }
 
 main()

--- a/scripts/clean-cli-templates.ts
+++ b/scripts/clean-cli-templates.ts
@@ -10,10 +10,10 @@ const gitIgnored = [
     "web-app/.next"
 ]
 
-const packages = ["cli-template-monorepo-ethers", "cli-template-monorepo-subgraph"]
+const folders = ["cli-template-monorepo-ethers", "cli-template-monorepo-subgraph"]
 
 async function main() {
-    packages.map((pkg) =>
+    folders.map((pkg) =>
         gitIgnored.map((f) => rmSync(`${folderName}/${pkg}/apps/${f}`, { recursive: true, force: true }))
     )
 }

--- a/scripts/clean-packages.ts
+++ b/scripts/clean-packages.ts
@@ -5,11 +5,11 @@ const folderName = "packages"
 const gitIgnored = ["node_modules", "dist", "build", "ptau", "artifacts", "typechain-types", "cache"]
 
 async function main() {
-    const apps = readdirSync(folderName, { withFileTypes: true })
+    const folders = readdirSync(folderName, { withFileTypes: true })
         .filter((file) => file.isDirectory())
         .map((dir) => dir.name)
 
-    apps.map((app) => gitIgnored.map((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })))
+    folders.map((app) => gitIgnored.map((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })))
 
     rmSync(`${folderName}/circuit/main`, { recursive: true, force: true })
     rmSync(`${folderName}/circuit/test`, { recursive: true, force: true })

--- a/scripts/remove-stable-version-field.ts
+++ b/scripts/remove-stable-version-field.ts
@@ -1,0 +1,27 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs"
+
+const folderName = "packages"
+
+async function main() {
+    const filePaths = readdirSync(folderName, { withFileTypes: true })
+        .filter((file) => file.isDirectory())
+        .map((dir) => (dir.name === "contracts" ? `${dir.name}/contracts` : dir.name))
+        .map((name) => `${folderName}/${name}/package.json`)
+
+    for (const filePath of filePaths) {
+        const content = JSON.parse(readFileSync(filePath, "utf8"))
+
+        if (content.stableVersion) {
+            delete content.stableVersion
+        }
+
+        writeFileSync(filePath, JSON.stringify(content, null, 4), "utf8")
+    }
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error)
+        process.exit(1)
+    })


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

This PR adds a script to automatically remove the `stableVersion` field created by Yarn when bumping a new pre-release version. `stableVersion` it is not actually necessary and it leads to unexpected outputs.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #305

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
