### PR TITLE
Add tree depth constants to JavaScript libraries and Solidity contracts

### DIFF
--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.23;
 import {ISemaphore} from "./interfaces/ISemaphore.sol";
 import {ISemaphoreVerifier} from "./interfaces/ISemaphoreVerifier.sol";
 import {SemaphoreGroups} from "./base/SemaphoreGroups.sol";
+import {MIN_DEPTH, MAX_DEPTH} from "./base/Constants.sol";
 
 /// @title Semaphore
 /// @dev This contract uses the Semaphore base contracts to provide a complete service
@@ -13,12 +14,6 @@ import {SemaphoreGroups} from "./base/SemaphoreGroups.sol";
 /// within which the proofs generated with that root can be validated.
 contract Semaphore is ISemaphore, SemaphoreGroups {
     ISemaphoreVerifier public verifier;
-
-    /// @dev Minimum supported tree depth.
-    uint8 public constant MIN_DEPTH = 1;
-
-    /// @dev Maximum supported tree depth.
-    uint8 public constant MAX_DEPTH = 12;
 
     /// @dev Gets a group id and returns the group parameters.
     mapping(uint256 => Group) public groups;

--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -14,6 +14,12 @@ import {SemaphoreGroups} from "./base/SemaphoreGroups.sol";
 contract Semaphore is ISemaphore, SemaphoreGroups {
     ISemaphoreVerifier public verifier;
 
+    /// @dev Minimum supported tree depth.
+    uint8 public constant MIN_DEPTH = 1;
+
+    /// @dev Maximum supported tree depth.
+    uint8 public constant MAX_DEPTH = 12;
+
     /// @dev Gets a group id and returns the group parameters.
     mapping(uint256 => Group) public groups;
 
@@ -130,7 +136,7 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
         SemaphoreProof calldata proof
     ) public view override onlyExistingGroup(groupId) returns (bool) {
         // The function will revert if the Merkle tree depth is not supported.
-        if (proof.merkleTreeDepth < 1 || proof.merkleTreeDepth > 12) {
+        if (proof.merkleTreeDepth < MIN_DEPTH || proof.merkleTreeDepth > MAX_DEPTH) {
             revert Semaphore__MerkleTreeDepthIsNotSupported();
         }
 

--- a/packages/contracts/contracts/base/Constants.sol
+++ b/packages/contracts/contracts/base/Constants.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+/// @dev Minimum supported tree depth.
+uint8 constant MIN_DEPTH = 1;
+
+/// @dev Maximum supported tree depth.
+uint8 constant MAX_DEPTH = 12;

--- a/packages/contracts/contracts/base/SemaphoreVerifier.sol
+++ b/packages/contracts/contracts/base/SemaphoreVerifier.sol
@@ -3,6 +3,8 @@
 
 pragma solidity 0.8.23;
 
+import {MAX_DEPTH} from "./Constants.sol";
+
 contract SemaphoreVerifier {
     // Scalar field size
     uint256 constant r = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
@@ -27,7 +29,7 @@ contract SemaphoreVerifier {
     // Verification Key points.
     // These values are taken from the verification key json file generated with snarkjs.
     // It allows to use the same verifier to verify proofs for all the tree depths supported by Semaphore.
-    uint256[14][12] VK_POINTS = [
+    uint256[14][MAX_DEPTH] VK_POINTS = [
         [
             563562783592406106461234396505774794044312891062077216951605541624542949349,
             16293410697967515504861065986355060225819302510590370360517024529684437085892,

--- a/packages/contracts/contracts/base/SemaphoreVerifier.sol
+++ b/packages/contracts/contracts/base/SemaphoreVerifier.sol
@@ -24,7 +24,7 @@ contract SemaphoreVerifier {
     uint256 constant gammay2 = 8495653923123431417604973247489272438418190587263600148770280649306958101930;
 
     // TODO: Add more variables when Semaphore supports tree depth > 12.
-    // Right now Semaphore supports tree depth 1-12.
+    // Right now Semaphore supports tree depth 1-12. It will support up to 32.
 
     // Verification Key points.
     // These values are taken from the verification key json file generated with snarkjs.

--- a/packages/proof/src/generate-proof.ts
+++ b/packages/proof/src/generate-proof.ts
@@ -1,6 +1,7 @@
 import type { Group, MerkleProof } from "@semaphore-protocol/group"
 import type { Identity } from "@semaphore-protocol/identity"
 import { requireDefined, requireNumber, requireObject, requireTypes } from "@semaphore-protocol/utils/errors"
+import { MIN_DEPTH, MAX_DEPTH } from "@semaphore-protocol/utils/constants"
 import { NumericString, groth16 } from "snarkjs"
 import { packGroth16Proof } from "@zk-kit/utils/proof-packing"
 import getSnarkArtifacts from "./get-snark-artifacts.node"
@@ -73,8 +74,8 @@ export default async function generateProof(
     const merkleProofLength = merkleProof.siblings.length
 
     if (merkleTreeDepth !== undefined) {
-        if (merkleTreeDepth < 1 || merkleTreeDepth > 12) {
-            throw new TypeError("The tree depth must be a number between 1 and 12")
+        if (merkleTreeDepth < MIN_DEPTH || merkleTreeDepth > MAX_DEPTH) {
+            throw new TypeError(`The tree depth must be a number between ${MIN_DEPTH} and ${MAX_DEPTH}`)
         }
     } else {
         merkleTreeDepth = merkleProofLength

--- a/packages/proof/src/verify-proof.ts
+++ b/packages/proof/src/verify-proof.ts
@@ -5,6 +5,7 @@ import {
     requireObject,
     requireString
 } from "@semaphore-protocol/utils/errors"
+import { MIN_DEPTH, MAX_DEPTH } from "@semaphore-protocol/utils/constants"
 import { groth16 } from "snarkjs"
 import { unpackGroth16Proof } from "@zk-kit/utils/proof-packing"
 import hash from "./hash"
@@ -31,8 +32,8 @@ export default async function verifyProof(proof: SemaphoreProof): Promise<boolea
     requireArray(points, "proof.points")
 
     // TODO: support all tree depths after trusted-setup.
-    if (merkleTreeDepth < 1 || merkleTreeDepth > 12) {
-        throw new TypeError("The tree depth must be a number between 1 and 12")
+    if (merkleTreeDepth < MIN_DEPTH || merkleTreeDepth > MAX_DEPTH) {
+        throw new TypeError(`The tree depth must be a number between ${MIN_DEPTH} and ${MAX_DEPTH}`)
     }
 
     const verificationKey = {

--- a/packages/proof/src/verify-proof.ts
+++ b/packages/proof/src/verify-proof.ts
@@ -31,7 +31,6 @@ export default async function verifyProof(proof: SemaphoreProof): Promise<boolea
     requireString(scope, "proof.scope")
     requireArray(points, "proof.points")
 
-    // TODO: support all tree depths after trusted-setup.
     if (merkleTreeDepth < MIN_DEPTH || merkleTreeDepth > MAX_DEPTH) {
         throw new TypeError(`The tree depth must be a number between ${MIN_DEPTH} and ${MAX_DEPTH}`)
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,6 +21,11 @@
             "types": "./dist/types/types.d.ts",
             "require": "./dist/lib.commonjs/types.cjs",
             "default": "./dist/lib.esm/types.js"
+        },
+        "./constants": {
+            "types": "./dist/types/constants.d.ts",
+            "require": "./dist/lib.commonjs/constants.cjs",
+            "default": "./dist/lib.esm/constants.js"
         }
     },
     "files": [

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,3 +1,5 @@
+// TODO: Support all tree depths after trusted-setup. MAX_DEPTH would be 32.
+
 export const MIN_DEPTH = 1
 
 export const MAX_DEPTH = 12

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,0 +1,3 @@
+export const MIN_DEPTH = 1
+
+export const MAX_DEPTH = 12

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 import * as errors from "./errors"
 import * as types from "./types"
+import * as constants from "./constants"
 
-export { errors, types }
+export { errors, types, constants }


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

This PR adds tree depth constants to JavaScript libraries and Solidity contracts to follow good practices and make it easier to update these important values. 

- JavaScript libraries:

There is a new export in the `@semaphore-protocol/utils` library called `constants` which has the minimum and maximum Semaphore supported tree depth. 

- Solidity contracts:

There is a new file called `Constants.sol` in the `packages/contracts/contracts/base` folder which has the minimum and maximum Semaphore supported tree depth. 

With these updates, when the supported tree depths change, only these two files should be updated with the `VK_POINTS` variable in the `SemaphoreVerifier.sol` contract.

## Related Issue(s)

Closes #683

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
