### PR TITLE
chore(circuits): fix groth16 malleability broken link

### DIFF
--- a/packages/circuits/semaphore.circom
+++ b/packages/circuits/semaphore.circom
@@ -62,6 +62,6 @@ template Semaphore(MAX_DEPTH) {
     // The message is not really used within the circuit.
     // The square applied to it is a way to force Circom's compiler to add a constraint and
     // prevent its value from being changed by an attacker.
-    // More information here: https://geometryresearch.xyz/notebook/groth16-malleability.
+    // More information here: https://geometry.xyz/notebook/groth16-malleability.
     signal dummySquare <== message * message;
 }


### PR DESCRIPTION
## Description
Fixes a broken link that references the groth16 malleability

## Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
