### PR TITLE
Convert hexadecimal private key before signing messages

### DIFF
--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -112,7 +112,11 @@ export class Identity {
      * @returns A {@link https://zkkit.pse.dev/types/_zk_kit_eddsa_poseidon.Signature.html | Signature} object containing the signature components.
      */
     public signMessage(message: BigNumberish): Signature<bigint> {
-        return signMessage(this.privateKey, message)
+        const privateKey = isHexadecimal(this.privateKey, false)
+            ? hexadecimalToBuffer(this.privateKey)
+            : this.privateKey
+
+        return signMessage(privateKey, message)
     }
 
     /**

--- a/packages/identity/tests/index.test.ts
+++ b/packages/identity/tests/index.test.ts
@@ -62,7 +62,7 @@ describe("Identity", () => {
             expect(Identity.verifySignature("message", signature, identity.publicKey)).toBeTruthy()
         })
 
-        it("Should verify a signature hexadecimal private key", () => {
+        it("Should verify a signature with hexadecimal private key", () => {
             const identity = new Identity(privateKeyHexadecimal)
 
             const signature = identity.signMessage("message")

--- a/packages/identity/tests/index.test.ts
+++ b/packages/identity/tests/index.test.ts
@@ -54,8 +54,16 @@ describe("Identity", () => {
     })
 
     describe("# verifySignature", () => {
-        it("Should verify a signature", () => {
+        it("Should verify a signature with a text private key", () => {
             const identity = new Identity(privateKeyText)
+
+            const signature = identity.signMessage("message")
+
+            expect(Identity.verifySignature("message", signature, identity.publicKey)).toBeTruthy()
+        })
+
+        it("Should verify a signature hexadecimal private key", () => {
+            const identity = new Identity(privateKeyHexadecimal)
 
             const signature = identity.signMessage("message")
 


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

The ZK-Kit EdDSA Poseidon package only supports the following private key types: text, buffer. The Semaphore identity supports text and hexadecimal strings. If the identity private key is a hexadicimal string it needs to be converted before being passed to any ZK-Kit function.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Fixes #733

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
