### PR TITLE
Add check to make sure Baby Jubjub secret scalar is < l 

### DIFF
--- a/packages/circuits/circomkit.json
+++ b/packages/circuits/circomkit.json
@@ -4,7 +4,7 @@
     "version": "2.1.5",
     "circuits": "./circuits.json",
     "dirPtau": "./ptau",
-    "dirCircuits": "./",
+    "dirCircuits": "./src",
     "dirInputs": "./inputs",
     "dirBuild": "./build",
     "optimization": 2,

--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -28,9 +28,9 @@
         "circomlib": "2.0.5"
     },
     "devDependencies": {
+        "@semaphore-protocol/core": "workspace:^",
         "@types/mocha": "^10.0.6",
-        "@zk-kit/eddsa-poseidon": "0.6.0",
-        "@zk-kit/imt": "^2.0.0-beta.2",
+        "@zk-kit/baby-jubjub": "1.0.0-beta",
         "circomkit": "^0.0.19",
         "mocha": "^10.2.0",
         "poseidon-lite": "^0.2.0"

--- a/packages/circuits/src/semaphore.circom
+++ b/packages/circuits/src/semaphore.circom
@@ -3,6 +3,7 @@ pragma circom 2.1.5;
 include "babyjub.circom";
 include "poseidon.circom";
 include "binary-merkle-root.circom";
+include "comparators.circom";
 
 // The Semaphore circuit can be divided into 3 main parts.
 // The first part involves the generation of the Semaphore identity,
@@ -33,6 +34,17 @@ template Semaphore(MAX_DEPTH) {
     // Output signals.
     // The output signals are all public.
     signal output merkleRoot, nullifier;
+
+    // The secret scalar must be in the prime subgroup order 'r'.
+    var r = 2736030358979909402780800718157159386076813972158567259200215660948447373041;
+
+    component isLessThan = LessThan(252);
+    isLessThan.in <== [secret, r];
+    isLessThan.out === 1;
+
+    component isGreaterThan = GreaterThan(252);
+    isGreaterThan.in <== [secret, 0];
+    isGreaterThan.out === 1;
 
     // Identity generation.
     // The circuit derives the EdDSA public key from a secret using

--- a/packages/circuits/src/semaphore.circom
+++ b/packages/circuits/src/semaphore.circom
@@ -35,16 +35,12 @@ template Semaphore(MAX_DEPTH) {
     // The output signals are all public.
     signal output merkleRoot, nullifier;
 
-    // The secret scalar must be in the prime subgroup order 'r'.
-    var r = 2736030358979909402780800718157159386076813972158567259200215660948447373041;
+    // The secret scalar must be in the prime subgroup order 'l'.
+    var l = 2736030358979909402780800718157159386076813972158567259200215660948447373041;
 
-    component isLessThan = LessThan(252);
-    isLessThan.in <== [secret, r];
+    component isLessThan = LessThan(251);
+    isLessThan.in <== [secret, l];
     isLessThan.out === 1;
-
-    component isGreaterThan = GreaterThan(252);
-    isGreaterThan.in <== [secret, 0];
-    isGreaterThan.out === 1;
 
     // Identity generation.
     // The circuit derives the EdDSA public key from a secret using

--- a/packages/circuits/tests/common.ts
+++ b/packages/circuits/tests/common.ts
@@ -1,3 +1,4 @@
+import type { Group } from "@semaphore-protocol/core"
 import { Circomkit } from "circomkit"
 import { readFileSync } from "fs"
 import path from "path"
@@ -5,8 +6,27 @@ import path from "path"
 const configFilePath = path.join(__dirname, "../circomkit.json")
 const config = JSON.parse(readFileSync(configFilePath, "utf-8"))
 
-// eslint-disable-next-line import/prefer-default-export
 export const circomkit = new Circomkit({
     ...config,
     verbose: false
 })
+
+export function generateMerkleProof(group: Group, _index: number, maxDepth: number) {
+    const { siblings: merkleProofSiblings, index } = group.generateMerkleProof(_index)
+
+    // The index must be converted to a list of indices, 1 for each tree level.
+    // The circuit tree depth is 20, so the number of siblings must be 20, even if
+    // the tree depth is actually 3. The missing siblings can be set to 0, as they
+    // won't be used to calculate the root in the circuit.
+    const merkleProofIndices: number[] = []
+
+    for (let i = 0; i < maxDepth; i += 1) {
+        merkleProofIndices.push((index >> i) & 1)
+
+        if (merkleProofSiblings[i] === undefined) {
+            merkleProofSiblings[i] = BigInt(0)
+        }
+    }
+
+    return { merkleProofSiblings, merkleProofIndices }
+}

--- a/packages/circuits/tsconfig.json
+++ b/packages/circuits/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "target": "es2020",
+        "module": "commonjs",
+        "esModuleInterop": true
+    },
+    "include": ["tests/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6330,10 +6330,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@semaphore-protocol/circuits@workspace:packages/circuits"
   dependencies:
+    "@semaphore-protocol/core": "workspace:^"
     "@types/mocha": "npm:^10.0.6"
+    "@zk-kit/baby-jubjub": "npm:^1.0.0-beta"
     "@zk-kit/circuits": "npm:0.2.4"
-    "@zk-kit/eddsa-poseidon": "npm:0.6.0"
-    "@zk-kit/imt": "npm:^2.0.0-beta.2"
     circomkit: "npm:^0.0.19"
     circomlib: "npm:2.0.5"
     mocha: "npm:^10.2.0"
@@ -6436,7 +6436,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@semaphore-protocol/core@npm:4.0.0-beta.7, @semaphore-protocol/core@workspace:packages/core":
+"@semaphore-protocol/core@npm:4.0.0-beta.7, @semaphore-protocol/core@workspace:^, @semaphore-protocol/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@semaphore-protocol/core@workspace:packages/core"
   dependencies:
@@ -8645,21 +8645,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zk-kit/baby-jubjub@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@zk-kit/baby-jubjub@npm:0.2.0"
-  dependencies:
-    "@zk-kit/utils": "npm:0.3.0"
-  checksum: 10/764804bd96adaa2b7df3110d64ef327e6ab0d2c4bf0fe60a81ed6be3770ee6b6e74d1f67e574be23bd830aa1c8ce94137f909d5d4fde7005bc50ca82d0ee6c10
-  languageName: node
-  linkType: hard
-
 "@zk-kit/baby-jubjub@npm:0.3.0":
   version: 0.3.0
   resolution: "@zk-kit/baby-jubjub@npm:0.3.0"
   dependencies:
     "@zk-kit/utils": "npm:0.6.0"
   checksum: 10/a5b6f80e277c90be6874f60632cb3818ac3267434c52173474bc475798237e0c0fee92522a434cb2cb8b512b3246d5fb41ae38b117aeeb814b62f57875cfc6d9
+  languageName: node
+  linkType: hard
+
+"@zk-kit/baby-jubjub@npm:^1.0.0-beta":
+  version: 1.0.0-beta
+  resolution: "@zk-kit/baby-jubjub@npm:1.0.0-beta"
+  dependencies:
+    "@zk-kit/utils": "npm:1.0.0-beta"
+  checksum: 10/417b15946916a398117e55c7293391c3231d5d9b59deda7a745e80ca8816fa79048bcfc0dec9ed490fec9599e1bee1d73c3148b53e373a1faea57f20d5af9afd
   languageName: node
   linkType: hard
 
@@ -8683,16 +8683,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zk-kit/eddsa-poseidon@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@zk-kit/eddsa-poseidon@npm:0.6.0"
-  dependencies:
-    "@zk-kit/baby-jubjub": "npm:0.2.0"
-    "@zk-kit/utils": "npm:0.3.0"
-  checksum: 10/ba32c455675d82ceb88eba30ff9907d80bab266fb3fc2fe9ebf5945c39e23d833b752fb67b8ac3dba294d457918b3178e4c390df45fb587d358352110974e45c
-  languageName: node
-  linkType: hard
-
 "@zk-kit/imt.sol@npm:2.0.0-beta.8":
   version: 2.0.0-beta.8
   resolution: "@zk-kit/imt.sol@npm:2.0.0-beta.8"
@@ -8706,20 +8696,6 @@ __metadata:
   version: 2.0.0-beta.2
   resolution: "@zk-kit/imt@npm:2.0.0-beta.2"
   checksum: 10/b99ab587f4a5f147531160feb9b27e5505659d5bb34fe2cbbc8e3d3bedc95febb3cf1ffcd4f75570feb03a2d929063e9b5f9d638ac2c1bba0204ca9cdc1fa2c0
-  languageName: node
-  linkType: hard
-
-"@zk-kit/imt@npm:^2.0.0-beta.2":
-  version: 2.0.0-beta.3
-  resolution: "@zk-kit/imt@npm:2.0.0-beta.3"
-  checksum: 10/d0eaa0ab98c42d12b13e42c6842e49aaeae48a50ccc54bce9c8d4bd18fe35f58bb46967ab82df09462c1788b4d814bc2e64d0048dc94cac8803d2bbc08f0f5fe
-  languageName: node
-  linkType: hard
-
-"@zk-kit/utils@npm:0.3.0":
-  version: 0.3.0
-  resolution: "@zk-kit/utils@npm:0.3.0"
-  checksum: 10/aa889d4ad2f88930a327bf987c95f8b9b4ece0b39b6f7685d14d1fd3803475e6900a9db489f876ae9d4b3a1e4cb99313870969c9b67b089d45b75f8faf44ffd5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6332,7 +6332,7 @@ __metadata:
   dependencies:
     "@semaphore-protocol/core": "workspace:^"
     "@types/mocha": "npm:^10.0.6"
-    "@zk-kit/baby-jubjub": "npm:^1.0.0-beta"
+    "@zk-kit/baby-jubjub": "npm:1.0.0-beta"
     "@zk-kit/circuits": "npm:0.2.4"
     circomkit: "npm:^0.0.19"
     circomlib: "npm:2.0.5"
@@ -8654,7 +8654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zk-kit/baby-jubjub@npm:^1.0.0-beta":
+"@zk-kit/baby-jubjub@npm:1.0.0-beta":
   version: 1.0.0-beta
   resolution: "@zk-kit/baby-jubjub@npm:1.0.0-beta"
   dependencies:


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

The `BabyPbk` Circomlib's template needs a check on the input to make sure `s` (secret scalar defined here: https://www.rfc-editor.org/rfc/rfc8032.html#section-5.1.5) is < `l` (prime number of 251 bits defined here https://eips.ethereum.org/EIPS/eip-2494). This PR adds that check.

The secret scalar is generated outside circuits, with the [`@zk-kit/eddsa-poseidon`](https://github.com/privacy-scaling-explorations/zk-kit/blob/main/packages/eddsa-poseidon) package ([`deriveSecretScalar`](https://github.com/privacy-scaling-explorations/zk-kit/blob/4e6d3b2691de1f460af0cc6f88181829f46977f1/packages/eddsa-poseidon/src/eddsa-poseidon.ts#L47) function), and according to the EdDSA standard it is derived from a private key hashed with sha-3. ZK-Kit is currently using blake1.

This PR is also related to https://github.com/privacy-scaling-explorations/zk-kit/issues/239, which aims to make sure the secret scalar is always < `l`.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Fixes #744 
Re https://github.com/privacy-scaling-explorations/zk-kit/issues/239

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

This bug was found by the [Geometry team](https://geometry.dev). More info in #744.

The SNARK artifacts need to be generated again after this PR. 

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
