### PR TITLE
docs: fix `typedoc` compilation warnings

### DIFF
--- a/packages/group/src/index.ts
+++ b/packages/group/src/index.ts
@@ -144,10 +144,10 @@ export class Group {
      * @param nodes The stringified JSON of the group.
      * @returns The {@link Group} instance.
      */
-    static import(exportedGroup: string): Group {
+    static import(nodes: string): Group {
         const group = new Group()
 
-        group.leanIMT.import(exportedGroup)
+        group.leanIMT.import(nodes)
 
         return group
     }

--- a/packages/utils/src/networks/index.ts
+++ b/packages/utils/src/networks/index.ts
@@ -46,7 +46,7 @@ export function getHardhatNetworks(privateKey?: string) {
 /**
  * Returns name, address and start block of a Semaphore contract deployed
  * on a specific supported network.
- * @param The network supported by Semaphore.
+ * @param supportedNetwork The network supported by Semaphore.
  * @returns An object with name, address and start block of the deployed contract.
  */
 export function getDeployedContract(supportedNetwork: SupportedNetwork) {

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,0 +1,26 @@
+const fs = require("fs")
+const path = require("path")
+
+const EXCLUDE_PKGS = [
+    "cli-template",
+    "cli-template-contracts-hardhat",
+    "cli-template-monorepo-ethers",
+    "cli-template-monorepo-subgraph",
+    "core",
+    "circuits",
+    "contracts",
+    "hardhat",
+    "cli"
+]
+const packagesDir = path.join(__dirname, "packages")
+const entryPoints = fs
+    .readdirSync(packagesDir, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory() && !EXCLUDE_PKGS.includes(dirent.name))
+    .map((dirent) => path.join("packages", dirent.name))
+
+/** @type {import('typedoc').typedocoptions} */
+module.exports = {
+    entryPoints,
+    name: "Semaphore SDK",
+    entryPointStrategy: "packages"
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,0 @@
-{
-    "entryPoints": ["packages/*"],
-    "name": "Semaphore SDK",
-    "entryPointStrategy": "packages",
-    "exclude": ["**/cli-template*", "**/circuits", "**/contracts", "**/hardhat", "**/cli"]
-}


### PR DESCRIPTION
Fix different warnings shown when building the docs.

Fixes #749

## Test plan
|Before|After|
|--|--|
|`yarn docs`: builds successfully but generates a bunch of warnings|`yarn docs`: builds successfully without warnings|
