### PR TITLE
ci: fix circom deps installation steps

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -82,8 +82,11 @@ jobs:
                   cache: yarn
 
             # https://github.com/iden3/circuits/blob/8fffb6609ecad0b7bcda19bb908bdb544bdb3cf7/.github/workflows/main.yml#L18-L22
+            # https://stackoverflow.com/a/78377916
             - name: Setup Circom deps
-              run: sudo apt-get update && sudo apt-get install -y wget nlohmann-json3-dev libgmp-dev nasm g++ build-essential
+              run: |
+                  sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+                  sudo apt-get update && sudo apt-get install -y wget nlohmann-json3-dev libgmp-dev nasm g++ build-essential
 
             - name: Setup Circom
               run: wget https://github.com/iden3/circom/releases/latest/download/circom-linux-amd64 && sudo mv ./circom-linux-amd64 /usr/bin/circom && sudo chmod +x /usr/bin/circom

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -52,8 +52,8 @@ jobs:
             # https://github.com/iden3/circuits/blob/8fffb6609ecad0b7bcda19bb908bdb544bdb3cf7/.github/workflows/main.yml#L18-L22
             - name: Setup Circom deps
               run: |
-                sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-                sudo apt-get update && sudo apt-get install -y wget nlohmann-json3-dev libgmp-dev nasm g++ build-essential
+                  sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+                  sudo apt-get update && sudo apt-get install -y wget nlohmann-json3-dev libgmp-dev nasm g++ build-essential
 
             - name: Setup Circom
               run: wget https://github.com/iden3/circom/releases/latest/download/circom-linux-amd64 && sudo mv ./circom-linux-amd64 /usr/bin/circom && sudo chmod +x /usr/bin/circom

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -50,6 +50,7 @@ jobs:
                   cache: yarn
 
             # https://github.com/iden3/circuits/blob/8fffb6609ecad0b7bcda19bb908bdb544bdb3cf7/.github/workflows/main.yml#L18-L22
+            # https://stackoverflow.com/a/78377916
             - name: Setup Circom deps
               run: |
                   sudo rm /etc/apt/sources.list.d/microsoft-prod.list

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -52,7 +52,7 @@ jobs:
             # https://github.com/iden3/circuits/blob/8fffb6609ecad0b7bcda19bb908bdb544bdb3cf7/.github/workflows/main.yml#L18-L22
             - name: Setup Circom deps
               run: |
-                ls -la /etc/apt/sources.list.d/
+                sudo rm /etc/apt/sources.list.d/microsoft-prod.list
                 sudo apt-get update && sudo apt-get install -y wget nlohmann-json3-dev libgmp-dev nasm g++ build-essential
 
             - name: Setup Circom

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -51,7 +51,9 @@ jobs:
 
             # https://github.com/iden3/circuits/blob/8fffb6609ecad0b7bcda19bb908bdb544bdb3cf7/.github/workflows/main.yml#L18-L22
             - name: Setup Circom deps
-              run: sudo apt-get update && sudo apt-get install -y wget nlohmann-json3-dev libgmp-dev nasm g++ build-essential
+              run: |
+                ls -la /etc/apt/sources.list.d/
+                sudo apt-get update && sudo apt-get install -y wget nlohmann-json3-dev libgmp-dev nasm g++ build-essential
 
             - name: Setup Circom
               run: wget https://github.com/iden3/circom/releases/latest/download/circom-linux-amd64 && sudo mv ./circom-linux-amd64 /usr/bin/circom && sudo chmod +x /usr/bin/circom


### PR DESCRIPTION
The circom deps in the pull requests workflow can't be install because there is an issue with their ubuntu repository (probably a temporary issue on the microsoft side related to their GPG keys).

As a temporary fix we can simply delete the microsoft source file in the workflow environment.
Besides, as long as the integrity checks of the packages we get from the microsoft repo are broken, I think it is fine to not fetch packages from their repo at all.
The drawback of not getting their softwares updates does not matter so much for us, as this is a ci environment we just use for running tests.

https://github.com/orgs/community/discussions/120966
https://stackoverflow.com/a/78377916