### PR TITLE
docs: fix 404 broken link to circuit file

### DIFF
--- a/apps/docs/versioned_docs/version-V4-beta/technical-reference/circuits.md
+++ b/apps/docs/versioned_docs/version-V4-beta/technical-reference/circuits.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Circuits
 
-The [Semaphore circuit](https://github.com/semaphore-protocol/semaphore/tree/main/packages/circuits/semaphore.circom) is the heart of the protocol and consists of three parts:
+The [Semaphore circuit](https://github.com/semaphore-protocol/semaphore/blob/main/packages/circuits/src/semaphore.circom) is the heart of the protocol and consists of three parts:
 
 -   [Proof of membership](#proof-of-membership)
 -   [Nullifier](#nullifier)


### PR DESCRIPTION
## Description

Broken since [this commit](https://github.com/semaphore-protocol/semaphore/commit/d9d5de1569470b57d326ed68248643126e3f24f1#diff-27cc20ba62610ee534566b1969efe92677c1c6af8940cdc20b57fcb0b4e0c6b3).

Doc page: https://docs.semaphore.pse.dev/technical-reference/circuits

## Related Issue(s)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
