### PR TITLE
fix(group): add check for zero values in group constructor

### DIFF
--- a/packages/group/src/index.ts
+++ b/packages/group/src/index.ts
@@ -23,6 +23,12 @@ export class Group {
      * @param members A list of identity commitments.
      */
     constructor(members: BigNumber[] = []) {
+        for (const member of members) {
+            if (member === 0n || member === "0") {
+                throw new Error("Failed to add member: value cannot be 0")
+            }
+        }
+
         this.leanIMT = new LeanIMT((a, b) => poseidon2([a, b]), members.map(BigInt))
     }
 

--- a/packages/group/tests/index.test.ts
+++ b/packages/group/tests/index.test.ts
@@ -23,6 +23,12 @@ describe("Group", () => {
             expect(group.depth).toBe(2)
             expect(group.size).toBe(3)
         })
+
+        it("Should not create a group with a list of members if any value is 0", () => {
+            const fun = () => new Group([1n, 0n])
+
+            expect(fun).toThrow("Failed to add member: value cannot be 0")
+        })
     })
 
     describe("# addMember", () => {


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

This PR adds a missing check in the Group class constructor to be sure there are no members with `0` as a value. 

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
