### PR TITLE
docs: add link to API Reference (typedoc)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,13 +2,19 @@ name: docs
 
 on:
     push:
-        branches:
-            - main
+        branches: [main]
+        paths:
+            [
+                "apps/docs/**",
+                "packages/data/**",
+                "packages/group/**",
+                "packages/identity/**",
+                "packages/proof/**",
+                "packages/utils/**"
+            ]
 
 jobs:
     gh-pages:
-        runs-on: ubuntu-latest
-
         steps:
             - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
     <h1 align="center">
       <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="https://github.com/semaphore-protocol/.github/blob/main/assets/semaphore-logo-light.svg">
-        <source media="(prefers-color-scheme: light)" srcset="https://github.com/semaphore-protocol/.github/blob/main/assets/semaphore-logo-dark.svg">
-        <img width="250" alt="Semaphore icon" src="https://github.com/semaphore-protocol/.github/blob/main/assets/semaphore-logo-dark.svg">
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/semaphore-protocol/.github/main/assets/semaphore-logo-light.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/semaphore-protocol/.github/main/assets/semaphore-logo-dark.svg">
+        <img width="250" alt="Semaphore icon" src="https://raw.githubusercontent.com/semaphore-protocol/.github/main/assets/semaphore-logo-dark.svg">
       </picture>
     </h1>
 </p>
@@ -55,6 +55,10 @@
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
         <a href="https://semaphore.pse.dev/discord">
             🗣️ Chat &amp; Support
+        </a>
+        <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+        <a href="https://js.semaphore.pse.dev">
+            💻 API Reference
         </a>
     </h4>
 </div>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "lint": "eslint . --ext .js,.ts,.tsx && yarn workspace semaphore-contracts lint",
         "format": "prettier -c . && yarn workspace semaphore-docs format",
         "format:write": "prettier -w . && yarn workspace semaphore-docs format:write",
-        "docs": "typedoc --cname js.semaphore.pse.dev",
+        "docs": "typedoc",
         "version:bump": "yarn workspaces foreach -A --no-private version -d ${0} && yarn version apply --all && yarn remove:stable-version-field && NO_HOOK=1 git commit -am \"chore: v${0}\" && git tag v${0}",
         "version:publish": "yarn build:libraries && yarn clean:cli-templates && yarn workspaces foreach -A --no-private npm publish --tolerate-republish --access public",
         "version:release": "changelogithub",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "lint": "eslint . --ext .js,.ts,.tsx && yarn workspace semaphore-contracts lint",
         "format": "prettier -c . && yarn workspace semaphore-docs format",
         "format:write": "prettier -w . && yarn workspace semaphore-docs format:write",
-        "docs": "typedoc --cname js.semaphore.pse.dev --githubPages true",
+        "docs": "typedoc --cname js.semaphore.pse.dev",
         "version:bump": "yarn workspaces foreach -A --no-private version -d ${0} && yarn version apply --all && yarn remove:stable-version-field && NO_HOOK=1 git commit -am \"chore: v${0}\" && git tag v${0}",
         "version:publish": "yarn build:libraries && yarn clean:cli-templates && yarn workspaces foreach -A --no-private npm publish --tolerate-republish --access public",
         "version:release": "changelogithub",

--- a/typedoc.js
+++ b/typedoc.js
@@ -10,8 +10,7 @@ const EXCLUDE_PKGS = [
     "cli-template-monorepo-subgraph",
     "contracts",
     "core",
-    "hardhat",
-    "heyauthn"
+    "hardhat"
 ]
 const packagesDir = path.join(__dirname, "packages")
 const entryPoints = fs

--- a/typedoc.js
+++ b/typedoc.js
@@ -2,15 +2,16 @@ const fs = require("fs")
 const path = require("path")
 
 const EXCLUDE_PKGS = [
+    "circuits",
+    "cli",
     "cli-template",
     "cli-template-contracts-hardhat",
     "cli-template-monorepo-ethers",
     "cli-template-monorepo-subgraph",
-    "core",
-    "circuits",
     "contracts",
+    "core",
     "hardhat",
-    "cli"
+    "heyauthn"
 ]
 const packagesDir = path.join(__dirname, "packages")
 const entryPoints = fs
@@ -20,6 +21,7 @@ const entryPoints = fs
 
 /** @type {import('typedoc').typedocoptions} */
 module.exports = {
+    cname: "js.semaphore.pse.dev",
     entryPoints,
     name: "Semaphore SDK",
     entryPointStrategy: "packages"


### PR DESCRIPTION
- fix rendering of image in typedoc website's homepage
  Currently we only see the `img` `alt` description
  ![image](https://github.com/semaphore-protocol/semaphore/assets/38692952/2ca7c15f-8a24-4549-8f13-267cccd7e683)
- shorten `docs` script (use config options in `typedoc.js` instead)
- optimize docs workflow: restrict the changed files that trigger it
- add link to `js.semaphore.pse.dev` in main README

