### PR TITLE
chore(proof): bump `@zk-kit/artifacts` to `1.4.1`

### DIFF
--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -53,7 +53,7 @@
     },
     "dependencies": {
         "@semaphore-protocol/utils": "4.0.0-beta.11",
-        "@zk-kit/artifacts": "^1.3.2",
+        "@zk-kit/artifacts": "1.4.1",
         "@zk-kit/utils": "1.0.0",
         "ethers": "6.10.0",
         "snarkjs": "0.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6412,7 +6412,7 @@ __metadata:
     "@rollup/plugin-typescript": "npm:^11.1.6"
     "@semaphore-protocol/utils": "npm:4.0.0-beta.11"
     "@types/snarkjs": "npm:^0"
-    "@zk-kit/artifacts": "npm:^1.3.2"
+    "@zk-kit/artifacts": "npm:1.4.1"
     "@zk-kit/utils": "npm:1.0.0"
     ethers: "npm:6.10.0"
     poseidon-lite: "npm:^0.2.0"
@@ -8462,10 +8462,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zk-kit/artifacts@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "@zk-kit/artifacts@npm:1.3.2"
-  checksum: 10/e3480397505dad5dbaeb704748c87045c268cccf614d9d3275fbbc45178657b83b1a7a12f3b4ddf561cf9e585bd6f1ca8ec65a03531c484bec1d154ff9252921
+"@zk-kit/artifacts@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@zk-kit/artifacts@npm:1.4.1"
+  checksum: 10/8ffacce0868eafb41679c0908c31f87e8cb75f9b5ab7ca3e55d69ba96765422af24669d230a019f65f4f796124d8cad2f0f80bce1aae02fc376f24c8ed46e4b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`maybeGetSnarkArtifacts` from `@zk-kit/artifacts@1.4.1` includes a retry mechanism as a workaround against the rate limiting issue we have been experiencing with unpkg.com ([see bad gateway error in ci](https://github.com/semaphore-protocol/semaphore/actions/runs/9317318980/job/25647368848#step:8:134)).

https://github.com/privacy-scaling-explorations/snark-artifacts/pull/66

