### PR TITLE
refactor(cli): create an empty yarn.lock file when generating a semahore project with the cli

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import chalk from "chalk"
 import { program } from "commander"
 import decompress from "decompress"
 import figlet from "figlet"
-import { copyFileSync, existsSync, readFileSync, unlinkSync } from "fs"
+import { copyFileSync, existsSync, readFileSync, unlinkSync, writeFileSync } from "fs"
 import logSymbols from "log-symbols"
 import pacote from "pacote"
 import { dirname } from "path"
@@ -99,6 +99,9 @@ program
             `${currentDirectory}/${projectDirectory}/.env.example`,
             `${currentDirectory}/${projectDirectory}/.env`
         )
+
+        // Create an empty yarn.lock file to install dependencies successfully
+        writeFileSync(`${currentDirectory}/${projectDirectory}/yarn.lock`, "")
 
         spinner.stop()
 


### PR DESCRIPTION
## Description

Now devs will be able to install dependencies successfully right after creating a project with the CLI.

## Related Issue(s)

Closes #827

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
