### PR TITLE
fix: update cli ethers and subgraph templates

### DIFF
--- a/packages/cli-template-monorepo-ethers/apps/web-app/src/app/groups/page.tsx
+++ b/packages/cli-template-monorepo-ethers/apps/web-app/src/app/groups/page.tsx
@@ -124,7 +124,7 @@ export default function GroupsPage() {
                 <div>
                     {_users.map((user, i) => (
                         <div key={i}>
-                            <p className="box box-text">{user}</p>
+                            <p className="box box-text">{user.toString()}</p>
                         </div>
                     ))}
                 </div>

--- a/packages/cli-template-monorepo-ethers/apps/web-app/src/components/PageContainer.tsx
+++ b/packages/cli-template-monorepo-ethers/apps/web-app/src/components/PageContainer.tsx
@@ -21,7 +21,7 @@ export default function PageContainer({
     useEffect(() => {
         semaphore.refreshUsers()
         semaphore.refreshFeedback()
-    }, [semaphore])
+    }, [])
 
     function getExplorerLink(network: SupportedNetwork, address: string) {
         switch (network) {

--- a/packages/cli-template-monorepo-subgraph/apps/web-app/next-env.d.ts
+++ b/packages/cli-template-monorepo-subgraph/apps/web-app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/cli-template-monorepo-subgraph/apps/web-app/src/app/groups/page.tsx
+++ b/packages/cli-template-monorepo-subgraph/apps/web-app/src/app/groups/page.tsx
@@ -124,7 +124,7 @@ export default function GroupsPage() {
                 <div>
                     {_users.map((user, i) => (
                         <div key={i}>
-                            <p className="box box-text">{user}</p>
+                            <p className="box box-text">{user.toString()}</p>
                         </div>
                     ))}
                 </div>

--- a/packages/cli-template-monorepo-subgraph/apps/web-app/src/components/PageContainer.tsx
+++ b/packages/cli-template-monorepo-subgraph/apps/web-app/src/components/PageContainer.tsx
@@ -21,7 +21,7 @@ export default function PageContainer({
     useEffect(() => {
         semaphore.refreshUsers()
         semaphore.refreshFeedback()
-    }, [semaphore])
+    }, [])
 
     function getExplorerLink(network: SupportedNetwork, address: string) {
         switch (network) {


### PR DESCRIPTION
## Description

This PR removes the `semaphore` object from the dependency array.

Context: https://github.com/facebook/react/issues/14920#issuecomment-467494468

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
