### PR TITLE
fix(proof): replace root public signal with actual root

### DIFF
--- a/packages/proof/src/generate-proof.ts
+++ b/packages/proof/src/generate-proof.ts
@@ -1,11 +1,11 @@
 import type { Group, MerkleProof } from "@semaphore-protocol/group"
 import type { Identity } from "@semaphore-protocol/identity"
 import { MAX_DEPTH, MIN_DEPTH } from "@semaphore-protocol/utils/constants"
+import { Project, maybeGetSnarkArtifacts, type SnarkArtifacts } from "@zk-kit/artifacts"
 import { requireDefined, requireNumber, requireObject, requireTypes } from "@zk-kit/utils/error-handlers"
 import { packGroth16Proof } from "@zk-kit/utils/proof-packing"
-import { maybeGetSnarkArtifacts, Project, type SnarkArtifacts } from "@zk-kit/artifacts"
 import type { BigNumberish } from "ethers"
-import { type NumericString, groth16 } from "snarkjs"
+import { groth16, type NumericString } from "snarkjs"
 import hash from "./hash"
 import toBigInt from "./to-bigint"
 import type { SemaphoreProof } from "./types"
@@ -118,7 +118,7 @@ export default async function generateProof(
 
     return {
         merkleTreeDepth,
-        merkleTreeRoot: publicSignals[0],
+        merkleTreeRoot: merkleProof.root.toString(),
         nullifier: publicSignals[1],
         message: message.toString() as NumericString,
         scope: scope.toString() as NumericString,

--- a/packages/proof/tests/index.test.ts
+++ b/packages/proof/tests/index.test.ts
@@ -55,7 +55,7 @@ describe("Proof", () => {
 
             expect(typeof proof).toBe("object")
             expect(BigInt(proof.merkleTreeRoot)).toBe(group.root)
-        }, 80000)
+        })
 
         it("Should generate a Semaphore proof passing a Merkle proof instead of a group", async () => {
             const group = new Group([1n, 2n, identity.commitment])
@@ -64,7 +64,7 @@ describe("Proof", () => {
 
             expect(typeof proof).toBe("object")
             expect(BigInt(proof.merkleTreeRoot)).toBe(group.root)
-        }, 80000)
+        })
 
         it("Should generate a Semaphore proof without passing the tree depth", async () => {
             const group = new Group([1n, 2n, identity.commitment])
@@ -73,7 +73,7 @@ describe("Proof", () => {
 
             expect(typeof proof).toBe("object")
             expect(BigInt(proof.merkleTreeRoot)).toBe(group.root)
-        }, 80000)
+        })
 
         it("Should throw an error because snarkArtifacts is not an object", async () => {
             const group = new Group([1n, 2n, identity.commitment])
@@ -103,7 +103,7 @@ describe("Proof", () => {
             await expect(fun).rejects.toThrow("tree depth must be")
         })
 
-        it("Should verify a Semaphore proof", async () => {
+        it("Should return true if the proof is valid", async () => {
             const group = new Group([1n, 2n, identity.commitment])
 
             const proof = await generateProof(identity, group, message, scope, treeDepth)
@@ -111,6 +111,16 @@ describe("Proof", () => {
             const response = await verifyProof(proof)
 
             expect(response).toBe(true)
-        }, 80_000)
+        })
+
+        it("Should return false if the proof is not valid", async () => {
+            const group = new Group([1n, 2n, identity.commitment])
+
+            const proof = await generateProof(identity, group.generateMerkleProof(0), message, scope, treeDepth)
+
+            const response = await verifyProof(proof)
+
+            expect(response).toBe(false)
+        })
     })
 })


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

For the proof to be valid, it is necessary that the group root passed as a parameter to the `generateProof` function matches the root returned by `groth16.fullProve` as a public signal.

There are two options for checking it:
1. The Semaphore proof keeps the public signals. And before verifying it devs will need to check that the root of the Semaphore proof matches the root of the group used to generate the proof (this is how V3 and current V4 work).
2. The Semaphore proof already returns the root that is expected to be correct (that of the group passed as a parameter). Devs will just need to verify the proof, which would fail if the roots don't match (this is how V4 will work, better DX).

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Fixes #842

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
