### PR TITLE
Semaphore Identity example code bug fix (Fix #848)

### DIFF
--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -125,7 +125,7 @@ import { Identity } from "@semaphore-protocol/identity"
 const message = "message"
 const identity = new Identity()
 
-const signature = identity.signMessage("message", signature)
+const signature = identity.signMessage("message")
 
 Identity.verifySignature(message, signature, identity.publicKey)
 ```

--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -125,7 +125,7 @@ import { Identity } from "@semaphore-protocol/identity"
 const message = "message"
 const identity = new Identity()
 
-const signature = identity.signMessage("message")
+const signature = identity.signMessage(message)
 
 Identity.verifySignature(message, signature, identity.publicKey)
 ```


### PR DESCRIPTION
**Description**
 
I deleted the undeclared input "signature" parameter in the `signMessage` function.

**Issue**

Closes #848

