### PR TITLE
ci: install `soldeer` in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - name: Install soldeer
+              uses: taiki-e/install-action@v2
+              with:
+                tool: soldeer
+
             - name: Install Node.js
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,12 @@ jobs:
             - name: Install soldeer
               uses: taiki-e/install-action@v2
               with:
-                tool: soldeer
+                  tool: soldeer
+            - name: Store soldeer login credential
+              env:
+                  SOLDEER_TOKEN: ${{ secrets.SOLDEER_TOKEN }}
+              run: |
+                  echo "$SOLDEER_TOKEN" > "$GITHUB_WORKSPACE"/soldeer_login
 
             - name: Install Node.js
               uses: actions/setup-node@v4
@@ -42,6 +47,7 @@ jobs:
               run: yarn version:publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  SOLDEER_LOGIN_FILE: ${{ github.workspace }}/soldeer_login
 
             - run: yarn version:release
               env:


### PR DESCRIPTION
Fix `soldeer` cli setup in release workflow.  
`soldeer push` needs an authentication token. 
However https://soldeer.xyz does not allow for creating api tokens or create teams.  
So I had to retrieve the token generated with a personal account locally.  
Token was retrieved with:
```commandline
soldeer login
cat ~/.soldeer/.soldeer_login
```

I added the content of this `.soldeer_login` file to the `SOLDEER_TOKEN` repo secret.

Once we have a shared mail address for the semaphore team. We should update the email address and token tied to the [`semaphore-protocol-contracts`](https://soldeer.xyz/project/soldeer-semaphore-contracts) soldeer project.


### Test
See this [comment](https://github.com/semaphore-protocol/semaphore/pull/868#issuecomment-2428439268) in branch used for testing