### PR TITLE
feat(identity): add generate commitment function

### DIFF
--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -138,4 +138,20 @@ export class Identity {
     static verifySignature(message: BigNumberish, signature: Signature, publicKey: Point): boolean {
         return verifySignature(message, signature, publicKey)
     }
+
+    /**
+     * Generates the commitment from the given public key.
+     * This static method is particularly useful after signature verification,
+     * as it allows retrieval of the corresponding commitment associated with the public key.
+     *
+     * @example
+     * const identity = new Identity()
+     * Identity.generateCommitment(identity.publicKey)
+     *
+     * @param publicKey The public key to generate the commitment.
+     * @returns The Semaphore identity commitment.
+     */
+    static generateCommitment(publicKey: Point): bigint {
+        return poseidon2(publicKey)
+    }
 }

--- a/packages/identity/tests/index.test.ts
+++ b/packages/identity/tests/index.test.ts
@@ -138,4 +138,14 @@ describe("Identity", () => {
             expect(Identity.verifySignature("message", signature, identity.publicKey)).toBeTruthy()
         })
     })
+
+    describe("# generateCommitment", () => {
+        it("Should generate the identity commitment from the public key", () => {
+            const identity = new Identity(privateKeyText)
+
+            const commitment = Identity.generateCommitment(identity.publicKey)
+
+            expect(identity.commitment).toBe(commitment)
+        })
+    })
 })


### PR DESCRIPTION
## Description

This static method is particularly useful after signature verification, as it allows retrieval of the corresponding commitment associated with the public key.

## Related Issue(s)

Closes #873

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
