### PR TITLE
refactor(contracts): specify gas cost in SemaphoreVerifier precompile calls

### DIFF
--- a/packages/contracts/contracts/base/SemaphoreVerifier.sol
+++ b/packages/contracts/contracts/base/SemaphoreVerifier.sol
@@ -59,11 +59,10 @@ contract SemaphoreVerifier {
                 mstore(add(mIn, 32), y)
                 mstore(add(mIn, 64), s)
 
-                // ref: https://www.evm.codes/precompiled 0x07 ecMul
-                // If inputs are valid, fixed gas cost 6000 is consumed.
-                // If inputs are invalid, all gas is consumed but is limited to 6000 in this case.
-                // `iszero(success)` will be true afterwards.
-                success := staticcall(6000, 7, mIn, 96, mIn, 64)
+                // ecMul gas cost is fixed at 6000. Add 33.3% gas for safety buffer.
+                // Last checked in 2024 Oct, evm codename Cancun
+                // ref: https://www.evm.codes/precompiled?fork=cancun#0x07
+                success := staticcall(8000, 7, mIn, 96, mIn, 64)
 
                 if iszero(success) {
                     mstore(0, 0)
@@ -73,11 +72,10 @@ contract SemaphoreVerifier {
                 mstore(add(mIn, 64), mload(pR))
                 mstore(add(mIn, 96), mload(add(pR, 32)))
 
-                // ref: https://www.evm.codes/precompiled 0x06 ecAdd
-                // If inputs are valid, fixed gas cost 150 is consumed.
-                // If inputs are invalid, all gas is consumed but is limited to 150 in this case.
-                // `iszero(success)` will be true afterwards.
-                success := staticcall(150, 6, mIn, 128, pR, 64)
+                // ecAdd gas cost is fixed at 150. Add 33.3% gas for safety buffer.
+                // Last checked in 2024 Oct, evm codename Cancun
+                // ref: https://www.evm.codes/precompiled?fork=cancun#0x06
+                success := staticcall(200, 6, mIn, 128, pR, 64)
 
                 if iszero(success) {
                     mstore(0, 0)
@@ -157,9 +155,10 @@ contract SemaphoreVerifier {
                 mstore(add(_pPairing, 704), mload(add(vkPoints, 64)))
                 mstore(add(_pPairing, 736), mload(add(vkPoints, 96)))
 
-                // ref: https://www.evm.codes/precompiled 0x08 ecPairing
-                // Given the input size 768 bytes, gas cost is computed from the above web page.
-                let success := staticcall(181000, 8, _pPairing, 768, _pPairing, 0x20)
+                // ecPairing gas cost at 181000 given 768 bytes input. Add 33.3% gas for safety buffer.
+                // Last checked in 2024 Oct, evm codename Cancun
+                // ref: https://www.evm.codes/precompiled?fork=cancun#0x08
+                let success := staticcall(241333, 8, _pPairing, 768, _pPairing, 0x20)
 
                 isOk := and(success, mload(_pPairing))
             }

--- a/packages/contracts/contracts/base/SemaphoreVerifier.sol
+++ b/packages/contracts/contracts/base/SemaphoreVerifier.sol
@@ -59,7 +59,7 @@ contract SemaphoreVerifier {
                 mstore(add(mIn, 32), y)
                 mstore(add(mIn, 64), s)
 
-                success := staticcall(sub(gas(), 2000), 7, mIn, 96, mIn, 64)
+                success := staticcall(gas(), 7, mIn, 96, mIn, 64)
 
                 if iszero(success) {
                     mstore(0, 0)
@@ -69,7 +69,7 @@ contract SemaphoreVerifier {
                 mstore(add(mIn, 64), mload(pR))
                 mstore(add(mIn, 96), mload(add(pR, 32)))
 
-                success := staticcall(sub(gas(), 2000), 6, mIn, 128, pR, 64)
+                success := staticcall(gas(), 6, mIn, 128, pR, 64)
 
                 if iszero(success) {
                     mstore(0, 0)
@@ -149,7 +149,7 @@ contract SemaphoreVerifier {
                 mstore(add(_pPairing, 704), mload(add(vkPoints, 64)))
                 mstore(add(_pPairing, 736), mload(add(vkPoints, 96)))
 
-                let success := staticcall(sub(gas(), 2000), 8, _pPairing, 768, _pPairing, 0x20)
+                let success := staticcall(gas(), 8, _pPairing, 768, _pPairing, 0x20)
 
                 isOk := and(success, mload(_pPairing))
             }

--- a/packages/contracts/contracts/base/SemaphoreVerifier.sol
+++ b/packages/contracts/contracts/base/SemaphoreVerifier.sol
@@ -59,7 +59,11 @@ contract SemaphoreVerifier {
                 mstore(add(mIn, 32), y)
                 mstore(add(mIn, 64), s)
 
-                success := staticcall(gas(), 7, mIn, 96, mIn, 64)
+                // ref: https://www.evm.codes/precompiled 0x07 ecMul
+                // If inputs are valid, fixed gas cost 6000 is consumed.
+                // If inputs are invalid, all gas is consumed but is limited to 6000 in this case.
+                // `iszero(success)` will be true afterwards.
+                success := staticcall(6000, 7, mIn, 96, mIn, 64)
 
                 if iszero(success) {
                     mstore(0, 0)
@@ -69,7 +73,11 @@ contract SemaphoreVerifier {
                 mstore(add(mIn, 64), mload(pR))
                 mstore(add(mIn, 96), mload(add(pR, 32)))
 
-                success := staticcall(gas(), 6, mIn, 128, pR, 64)
+                // ref: https://www.evm.codes/precompiled 0x06 ecAdd
+                // If inputs are valid, fixed gas cost 150 is consumed.
+                // If inputs are invalid, all gas is consumed but is limited to 150 in this case.
+                // `iszero(success)` will be true afterwards.
+                success := staticcall(150, 6, mIn, 128, pR, 64)
 
                 if iszero(success) {
                     mstore(0, 0)
@@ -149,7 +157,9 @@ contract SemaphoreVerifier {
                 mstore(add(_pPairing, 704), mload(add(vkPoints, 64)))
                 mstore(add(_pPairing, 736), mload(add(vkPoints, 96)))
 
-                let success := staticcall(gas(), 8, _pPairing, 768, _pPairing, 0x20)
+                // ref: https://www.evm.codes/precompiled 0x08 ecPairing
+                // Given the input size 768 bytes, gas cost is computed from the above web page.
+                let success := staticcall(181000, 8, _pPairing, 768, _pPairing, 0x20)
 
                 isOk := and(success, mload(_pPairing))
             }


### PR DESCRIPTION
## Description

Close #871 

## Other Info 

Original gas usage:

```
·-----------------------------------------------|---------------------------|-------------|-----------------------------·
|             Solc version: 0.8.23              ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
················································|···························|·············|······························
|  Methods                                                                                                              │
··············|·································|·············|·············|·············|···············|··············
|  Contract   ·  Method                         ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  acceptGroupAdmin               ·          -  ·          -  ·      29066  ·            2  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  addMember                      ·     117970  ·     157140  ·     133880  ·           15  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  addMembers                     ·     222218  ·     302814  ·     288637  ·            6  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  createGroup                    ·      54745  ·      91757  ·      82504  ·            4  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  createGroup                    ·          -  ·          -  ·      91038  ·            3  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  createGroup                    ·      74496  ·      91596  ·      90281  ·           26  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  removeMember                   ·          -  ·          -  ·     128981  ·            2  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  updateGroupAdmin               ·          -  ·          -  ·      48343  ·            4  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  updateGroupMerkleTreeDuration  ·          -  ·          -  ·      30748  ·            2  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  updateMember                   ·          -  ·          -  ·     212377  ·            2  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  validateProof                  ·          -  ·          -  ·     290144  ·            5  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Deployments                                  ·                                         ·  % of limit   ·             │
················································|·············|·············|·············|···············|··············
|  PoseidonT3                                   ·          -  ·          -  ·    3693362  ·       12.3 %  ·          -  │
················································|·············|·············|·············|···············|··············
|  Semaphore                                    ·          -  ·          -  ·    1820135  ·        6.1 %  ·          -  │
················································|·············|·············|·············|···············|··············
|  SemaphoreVerifier                            ·          -  ·          -  ·    3722864  ·       12.4 %  ·          -  │
·-----------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

With this PR (last updated 2024-10-31):

```
·-----------------------------------------------|---------------------------|-------------|-----------------------------·
|             Solc version: 0.8.23              ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
················································|···························|·············|······························
|  Methods                                                                                                              │
··············|·································|·············|·············|·············|···············|··············
|  Contract   ·  Method                         ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  acceptGroupAdmin               ·          -  ·          -  ·      29066  ·            2  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  addMember                      ·     117970  ·     157140  ·     133880  ·           15  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  addMembers                     ·     222218  ·     302814  ·     288637  ·            6  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  createGroup                    ·      54745  ·      91757  ·      82504  ·            4  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  createGroup                    ·          -  ·          -  ·      91038  ·            3  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  createGroup                    ·      74496  ·      91596  ·      90281  ·           26  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  removeMember                   ·          -  ·          -  ·     128981  ·            2  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  updateGroupAdmin               ·          -  ·          -  ·      48343  ·            4  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  updateGroupMerkleTreeDuration  ·          -  ·          -  ·      30748  ·            2  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  updateMember                   ·          -  ·          -  ·     212377  ·            2  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Semaphore  ·  validateProof                  ·          -  ·          -  ·     290063  ·            5  ·          -  │
··············|·································|·············|·············|·············|···············|··············
|  Deployments                                  ·                                         ·  % of limit   ·             │
················································|·············|·············|·············|···············|··············
|  PoseidonT3                                   ·          -  ·          -  ·    3693362  ·       12.3 %  ·          -  │
················································|·············|·············|·············|···············|··············
|  Semaphore                                    ·          -  ·          -  ·    1820135  ·        6.1 %  ·          -  │
················································|·············|·············|·············|···············|··············
|  SemaphoreVerifier                            ·          -  ·          -  ·    3721580  ·       12.4 %  ·          -  │
·-----------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
