### PR TITLE
feat(identity): export point and signature types

### DIFF
--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -129,3 +129,11 @@ const signature = identity.signMessage(message)
 
 Identity.verifySignature(message, signature, identity.publicKey)
 ```
+
+\# **Identity.generateCommitment**(publicKey: _Point_): _bigint_
+
+```typescript
+import { Identity } from "@semaphore-protocol/identity"
+
+Identity.generateCommitment(identity.publicKey)
+```

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -1,9 +1,12 @@
 import type { Point } from "@zk-kit/baby-jubjub"
-import { EdDSAPoseidon, Signature, signMessage, verifySignature } from "@zk-kit/eddsa-poseidon"
+import { EdDSAPoseidon, type Signature, signMessage, verifySignature } from "@zk-kit/eddsa-poseidon"
 import type { BigNumberish } from "@zk-kit/utils"
 import { base64ToBuffer, bufferToBase64, textToBase64 } from "@zk-kit/utils/conversions"
 import { isString } from "@zk-kit/utils/type-checks"
 import { poseidon2 } from "poseidon-lite/poseidon2"
+
+export type { Point }
+export type { Signature }
 
 /**
  * The Semaphore identity is essentially an {@link https://www.rfc-editor.org/rfc/rfc8032 | EdDSA}


### PR DESCRIPTION
## Description

This PR:

- Exports the `Point` and `Signature` types.
- Adds the `generateCommitment ` function to the Readme file.

## Related Issue(s)

Closes #885 

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
