### PR TITLE
docs(identity): add export import identity to the docs

### DIFF
--- a/apps/docs/versioned_docs/version-V4/guides/identities.mdx
+++ b/apps/docs/versioned_docs/version-V4/guides/identities.mdx
@@ -109,3 +109,33 @@ After a message is signed, anyone can verify the signature using the message its
 // Static method.
 Identity.verifySignature(message, signature, identity1.publicKey)
 ```
+
+## Export and import an identity
+
+A Semaphore Identity can be exported and then imported later for reuse. 
+
+### Export an identity
+
+Returns the private key encoded as a base64 string.
+
+```ts
+import { Identity } from "@semaphore-protocol/identity"
+
+const identity = new Identity()
+
+const privateKey = identity.export()
+```
+
+### Import an identity
+
+Returns a Semaphore identity based on a private key encoded as a base64 string. 
+
+```ts
+import { Identity } from "@semaphore-protocol/identity"
+
+const identity = new Identity()
+
+const privateKey = identity.export()
+
+const identity2 = Identity.import(privateKey)
+```


### PR DESCRIPTION
## Description

This PR modifies the Semaphore docs to add how to export and import a Semaphore v4 Identity.

## Related Issue(s)

Closes #872

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
