### PR TITLE
Fixed closing tag issue in Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ The core of the Semaphore protocol is in the [circuit logic](/packages/circuits/
                 </a>
             </td>
         </tr>
-    <tbody>
+    </tbody>
 </table>
 
 ## 🛠 Install


### PR DESCRIPTION
## Description

<img width="196" alt="Снимок экрана 2024-11-09 в 13 15 58" src="https://github.com/user-attachments/assets/585bb43b-8c52-4ccc-942a-5e443b8cb096">

In the table section, there is a minor mistake in the closing tag. Instead of using `</tbody>`, it should be `</tbody>`.

This is a formatting mistake.

Fixed.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
