### PR TITLE
Fix incorrect nesting of tags in README.md

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,9 +1,7 @@
-<p align="center">
-    <h1 align="center">
-        Semaphore CLI
-    </h1>
-    <p align="center">A command line tool to set up your Semaphore project and get group data.</p>
-</p>
+<h1 align="center">
+    Semaphore CLI
+</h1>
+<p align="center">A command line tool to set up your Semaphore project and get group data.</p>
 
 <p align="center">
     <a href="https://github.com/semaphore-protocol">


### PR DESCRIPTION
**Description**:  
This pull request addresses an issue in the README file where the `<h1>` tag was incorrectly nested inside a `<p>` tag. In HTML, the `<h1>` tag is a block-level element, while the `<p>` tag is an inline element. This incorrect nesting leads to invalid HTML structure, which can cause rendering issues and break the layout in some cases.

### Fix:
The following incorrect nesting:
```html
<p align="center">
    <h1 align="center">
        Semaphore CLI
    </h1>
    <p align="center">A command line tool to set up your Semaphore project and get group data.</p>
</p>
```
has been corrected to:
```html
<h1 align="center">
    Semaphore CLI
</h1>
<p align="center">A command line tool to set up your Semaphore project and get group data.</p>
```

This change ensures that the structure of the document is semantically correct and will render as intended across different browsers and platforms.

**Why this is important**:  
Correct HTML structure is critical for the proper display of content on web pages. Nested block-level elements like `<h1>` inside inline elements like `<p>` can cause layout issues or unexpected behavior, especially in older browsers or when using CSS frameworks. Fixing this ensures better compatibility and cleaner code.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [ ] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
