### PR TITLE
Fix incorrect closing tag README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ The core of the Semaphore protocol is in the [circuit logic](/packages/circuits/
                 </a>
             </td>
         </tr>
-    <tbody>
+    </tbody>
 </table>
 
 ## 🛠 Install


### PR DESCRIPTION
## Description

### Fix incorrect closing tag for `<tbody>` element

I found a small issue with the HTML code where the closing tag for the `<tbody>` element was missing. Instead of properly closing the `<tbody>`, another `<tbody>` tag was used, which could lead to rendering issues.

### Issue:
```html
<tbody>
```

### Suggested fix:
The closing tag for the `<tbody>` element should be placed at the end of the table rows section:

```html
</tbody>
```

This fix ensures that the `<tbody>` element is properly closed, preventing potential issues with rendering and maintaining proper HTML structure.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
