### PR TITLE
fix: typos in documentation files

### DIFF
--- a/apps/docs/versioned_docs/version-V1/usage.md
+++ b/apps/docs/versioned_docs/version-V1/usage.md
@@ -26,7 +26,7 @@ With the Client contract as the owner of the Semaphore contract, the Client
 contract may call owner-only Semaphore functions such as
 `addExternalNullifier()`.
 
-## Add, deactivate, or reactivate external nullifiiers
+## Add, deactivate, or reactivate external nullifiers
 
 These functions add, deactivate, and reactivate an external nullifier respectively.
 As each identity can only signal once to an external nullifier, and as a signal

--- a/apps/docs/versioned_docs/version-V3/glossary.md
+++ b/apps/docs/versioned_docs/version-V3/glossary.md
@@ -37,7 +37,7 @@ For more information, see [Merkle tree in Wikipedia](https://en.wikipedia.org/wi
 
 ## Nullifier
 
-A value used to prevent double entry or double signalling.
+A value used to prevent double entry or double signaling.
 
 See [Circuit nullifier hash](/V3/technical-reference/circuits/#nullifier-hash).
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "nullifiiers" to "nullifiers".
Corrected "signalling" to "signaling".

Please review the changes and let me know if any additional changes are needed.