### PR TITLE
fix(ci): publish pkg if no releases yet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ permissions:
     contents: write
 
 on:
-    workflow_release:
+    workflow_dispatch:
     push:
         tags:
             - "v*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ permissions:
     contents: write
 
 on:
+    workflow_release:
     push:
         tags:
             - "v*"

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -10,10 +10,12 @@ async function maybePushToSoldeer() {
     const response = await fetch(
         "https://api.soldeer.xyz/api/v1/revision?project_name=semaphore-protocol-contracts&limit=1"
     )
-    const { data, status } = await response.json()
+    const { data } = await response.json()
 
-    // fail status if no version published at all yet
-    if (status === "fail" || compare(contractsLocalVersion, data[0].version) === 1)
+    if (
+        data.length === 0 || // data = [] if no version has ever been published yet
+        compare(contractsLocalVersion, data[0].version) === 1
+    )
         execSync(`soldeer push semaphore-protocol-contracts~${contractsLocalVersion} packages/contracts/contracts`, {
             stdio: "inherit"
         })


### PR DESCRIPTION
Fix [soldeer release workflow error.](https://github.com/semaphore-protocol/semaphore/actions/runs/12004310268/job/33459096994#step:8:241).

The condition to allow for initial publish was wrong.
E.g now there is no semaphore pkgs published on soldeer yet.
And https://api.soldeer.xyz/api/v1/revision?project_name=semaphore-protocol-contracts&limit=1 does not return `"status": "fail"` but just an empty data array.

```json
{"data":[],"status":"success"}
```

So instead I suggest checking against the length of the `data` array.

I am also allowing to manually trigger the release of the workflow (as this PR won't push new tags, the soldeer release workflow needs to be triggered manually)