### PR TITLE
typo fix Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ When you submit your PR (or later change that code), a CI build will automatical
 
 We always use ESLint and Prettier. To check that your code follows the rules, simply run the npm script `yarn lint`.
 
-### Commits rules
+### Commit rules
 
 For commits it is recommended to use [Conventional Commits](https://www.conventionalcommits.org).
 


### PR DESCRIPTION
### Description:

This pull request addresses a minor issue in the **"Contributing"** guidelines documentation where the section titled **"Commits rules"** was slightly misphrased. The section title has been changed to **"Commit rules"** to align with standard language use and improve clarity.

### Why this change is important:

The original phrasing "Commits rules" is grammatically unconventional. Using "Commit rules" as the title adheres to more common and natural phrasing, making the documentation clearer and more consistent with common writing practices.

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
