### PR TITLE
Fix typo in section.identities.box2.description Update code.json

### DIFF
--- a/apps/docs/i18n/es/code.json
+++ b/apps/docs/i18n/es/code.json
@@ -42,7 +42,7 @@
         "message": "Valores públicos"
     },
     "section.identities.box2.description": {
-        "message": "Semaphore utiliza la función hash Poseidon para crear el identtity commitment a partir de los valores privados. Los identity commitments se pueden compartir públicamente, de forma similar a las direcciones Ethereum."
+        "message": "Semaphore utiliza la función hash Poseidon para crear el identity commitment a partir de los valores privados. Los identity commitments se pueden compartir públicamente, de forma similar a las direcciones Ethereum."
     },
     "section.identities.box3.title": {
         "message": "Generar identidades"


### PR DESCRIPTION
### Description  
This update corrects a small but significant typo in the key `section.identities.box2.description` of the localization file. The word **"identtity"** contained an extra "t" and has been updated to the correct spelling: **"identity"**.  

#### Why this matters:  
Typos, especially in technical terms like "identity commitment," can reduce clarity and trustworthiness in documentation and user interfaces. Since this text explains a critical concept in Semaphore's privacy system, ensuring accuracy is essential to maintain the professionalism and comprehension of the project.  

This fix ensures that users and developers working with the Semaphore documentation or translations receive a polished and clear experience.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
