### PR TITLE
fix(group): after a sequence of updates a proof is invalid

### DIFF
--- a/packages/contracts/test/Semaphore.ts
+++ b/packages/contracts/test/Semaphore.ts
@@ -476,24 +476,20 @@ describe("Semaphore", () => {
             const group = new Group(members)
 
             // Create a group and add 3 members.
-            let transaction = await semaphoreContract["createGroup(address)"](accountAddresses[0])
+            await semaphoreContract["createGroup(address)"](accountAddresses[0])
 
-            const { logs } = (await transaction.wait()) as any
-
-            const [groupId] = logs[0].args
+            const groupId = 2
 
             // Adding members to group
 
-            transaction = await semaphoreContract.addMembers(groupId, members)
-            await transaction.wait()
+            await semaphoreContract.addMembers(groupId, members)
 
             // Remove the third member.
             {
                 group.removeMember(2)
                 const { siblings } = group.generateMerkleProof(2)
 
-                transaction = await semaphoreContract.removeMember(groupId, members[2], siblings)
-                await transaction.wait()
+                await semaphoreContract.removeMember(groupId, members[2], siblings)
             }
 
             // Update the second member.
@@ -501,14 +497,14 @@ describe("Semaphore", () => {
                 group.updateMember(1, members[2])
                 const { siblings } = group.generateMerkleProof(1)
 
-                transaction = await semaphoreContract.updateMember(groupId, members[1], members[2], siblings)
-                await transaction.wait()
+                await semaphoreContract.updateMember(groupId, members[1], members[2], siblings)
             }
 
             // Validate a proof.
+
             const proof = await generateProof(identity, group, 42, group.root)
 
-            transaction = await semaphoreContract.validateProof(groupId, proof)
+            const transaction = await semaphoreContract.validateProof(groupId, proof)
 
             await expect(transaction)
                 .to.emit(semaphoreContract, "ProofValidated")

--- a/packages/contracts/test/Semaphore.ts
+++ b/packages/contracts/test/Semaphore.ts
@@ -463,8 +463,65 @@ describe("Semaphore", () => {
 
             const proof = await generateProof(identity, group, message, group.root, merkleTreeDepth)
 
-            return { semaphoreContract, groupId, proof }
+            return { semaphoreContract, groupId, proof, accountAddresses }
         }
+
+        it("Should insert members,remove member,update member and verifyProof", async () => {
+            const { semaphoreContract, accountAddresses } = await loadFixture(deployValidateProofFixture)
+
+            const identity = new Identity("0")
+            const members = Array.from({ length: 3 }, (_, i) => new Identity(i.toString())).map(
+                ({ commitment }) => commitment
+            )
+            const group = new Group(members)
+
+            // Create a group and add 3 members.
+            let transaction = await semaphoreContract["createGroup(address)"](accountAddresses[0])
+
+            const { logs } = (await transaction.wait()) as any
+
+            const [groupId] = logs[0].args
+
+            // Adding members to group
+
+            transaction = await semaphoreContract.addMembers(groupId, members)
+            await transaction.wait()
+
+            // Remove the third member.
+            {
+                group.removeMember(2)
+                const { siblings } = group.generateMerkleProof(2)
+
+                transaction = await semaphoreContract.removeMember(groupId, members[2], siblings)
+                await transaction.wait()
+            }
+
+            // Update the second member.
+            {
+                group.updateMember(1, members[2])
+                const { siblings } = group.generateMerkleProof(1)
+
+                transaction = await semaphoreContract.updateMember(groupId, members[1], members[2], siblings)
+                await transaction.wait()
+            }
+
+            // Validate a proof.
+            const proof = await generateProof(identity, group, 42, group.root)
+
+            transaction = await semaphoreContract.validateProof(groupId, proof)
+
+            await expect(transaction)
+                .to.emit(semaphoreContract, "ProofValidated")
+                .withArgs(
+                    groupId,
+                    proof.merkleTreeDepth,
+                    proof.merkleTreeRoot,
+                    proof.nullifier,
+                    proof.message,
+                    proof.merkleTreeRoot,
+                    proof.points
+                )
+        })
 
         it("Should throw an exception if the proof is not valid", async () => {
             const { semaphoreContract, groupId, proof } = await loadFixture(deployValidateProofFixture)

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -36,7 +36,7 @@
         "rollup-plugin-cleanup": "^3.2.1"
     },
     "dependencies": {
-        "@zk-kit/lean-imt": "2.2.1",
+        "@zk-kit/lean-imt": "2.2.2",
         "@zk-kit/utils": "1.2.1",
         "poseidon-lite": "0.3.0"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7451,7 +7451,7 @@ __metadata:
   resolution: "@semaphore-protocol/group@workspace:packages/group"
   dependencies:
     "@rollup/plugin-typescript": "npm:^11.1.6"
-    "@zk-kit/lean-imt": "npm:2.2.1"
+    "@zk-kit/lean-imt": "npm:2.2.2"
     "@zk-kit/utils": "npm:1.2.1"
     poseidon-lite: "npm:0.3.0"
     rimraf: "npm:^5.0.5"
@@ -9589,12 +9589,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zk-kit/lean-imt@npm:2.2.1":
-  version: 2.2.1
-  resolution: "@zk-kit/lean-imt@npm:2.2.1"
+"@zk-kit/lean-imt@npm:2.2.2":
+  version: 2.2.2
+  resolution: "@zk-kit/lean-imt@npm:2.2.2"
   dependencies:
     "@zk-kit/utils": "npm:1.2.1"
-  checksum: 10/f57ba0ab15ff38609c352862b21023d370bd250c37c7ef15d4ee7724c8179a7fdd6647ac8a555e6cf523032d1c769fb9eae6de5364a97574224ff7de1a34f8a8
+  checksum: 10/321e1964a4a0b7a19083c01743f5ee2a7311b1eede6775ce952a6fecf07d347dc4cdb250a557ff459bc6d3bff030e2a571f5116510c2392ca523f50c4d02311d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

When a member is removed from the group (update a leaf with 0n) and then another member is updated, the root that is saved is not correct, so the proof that is generated is not valid.
This bug is fixed by updating the lean-imt library, which was recently updated.
I detected this when I was testing the script create-mock-groups.


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->
The fix
https://github.com/privacy-scaling-explorations/zk-kit/pull/355

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
