### PR TITLE
Fix Typo in Quick Setup Documentation

### DIFF
--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V2/quick-setup.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V2/quick-setup.md
@@ -58,7 +58,7 @@ Hardhat includes the Hardhat Network, a local Ethereum network for development.
 
 ## Install Semaphore packages
 
-Semaphore provides contracts, JavaScript libraries and an Hardhat plugin for developers building zero-knowledge applications.
+Semaphore provides contracts, JavaScript libraries and a Hardhat plugin for developers building zero-knowledge applications.
 
 -   `@semaphore-protocol/contracts` provides contracts to manage groups and verify Semaphore proofs on-chain.
 -   JavaScript libraries help developers build zero-knowledge applications.


### PR DESCRIPTION
This pull request corrects a grammatical error in the Spanish quick setup documentation for Semaphore.  

#### Changes:  
- Updated the phrase "an Hardhat plugin" to "a Hardhat plugin" for proper grammatical usage.  

#### Checklist:  
- [x] Verified that documentation changes follow grammar and style guidelines.  
- [x] Confirmed no new warnings or errors were introduced.  

Feel free to review and provide feedback. Thank you!  
