### PR TITLE
fix(core): bump ethers to v6.13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,10 +275,16 @@ Clone this repository:
 git clone https://github.com/semaphore-protocol/semaphore.git
 ```
 
-And install the dependencies:
+Install the dependencies:
 
 ```bash
 cd semaphore && yarn
+```
+
+And build the repositiory:
+
+```bash
+yarn build
 ```
 
 ## 📜 Usage

--- a/packages/cli-template-contracts-hardhat/package.json
+++ b/packages/cli-template-contracts-hardhat/package.json
@@ -59,7 +59,7 @@
         "eslint-config-airbnb-typescript": "^17.1.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
-        "ethers": "^6.4.0",
+        "ethers": "^6.13.4",
         "hardhat": "^2.20.1",
         "hardhat-gas-reporter": "^1.0.8",
         "prettier": "^3.2.5",

--- a/packages/cli-template-monorepo-ethers/apps/contracts/package.json
+++ b/packages/cli-template-monorepo-ethers/apps/contracts/package.json
@@ -38,7 +38,7 @@
         "eslint-config-airbnb-typescript": "^17.1.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
-        "ethers": "^6.4.0",
+        "ethers": "^6.13.4",
         "hardhat": "^2.20.1",
         "hardhat-gas-reporter": "^1.0.8",
         "prettier": "^3.2.5",

--- a/packages/cli-template-monorepo-ethers/apps/web-app/package.json
+++ b/packages/cli-template-monorepo-ethers/apps/web-app/package.json
@@ -12,7 +12,7 @@
         "@semaphore-protocol/core": "4.7.2",
         "@semaphore-protocol/data": "4.7.2",
         "@semaphore-protocol/utils": "4.7.2",
-        "ethers": "^6.11.1",
+        "ethers": "^6.13.4",
         "next": "14.1.0",
         "next-pwa": "^5.6.0",
         "react": "^18",

--- a/packages/cli-template-monorepo-subgraph/apps/contracts/package.json
+++ b/packages/cli-template-monorepo-subgraph/apps/contracts/package.json
@@ -38,7 +38,7 @@
         "eslint-config-airbnb-typescript": "^17.1.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
-        "ethers": "^6.4.0",
+        "ethers": "^6.13.4",
         "hardhat": "^2.20.1",
         "hardhat-gas-reporter": "^1.0.8",
         "prettier": "^3.2.5",

--- a/packages/cli-template-monorepo-subgraph/apps/web-app/package.json
+++ b/packages/cli-template-monorepo-subgraph/apps/web-app/package.json
@@ -12,7 +12,7 @@
         "@semaphore-protocol/core": "4.7.2",
         "@semaphore-protocol/data": "4.7.2",
         "@semaphore-protocol/utils": "4.7.2",
-        "ethers": "^6.11.1",
+        "ethers": "^6.13.4",
         "next": "14.1.0",
         "next-pwa": "^5.6.0",
         "react": "^18",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -29,7 +29,7 @@
         "@types/ncp": "^2",
         "@types/node": "^20.10.7",
         "chai": "^4.2.0",
-        "ethers": "^6.4.0",
+        "ethers": "^6.13.4",
         "hardhat": "^2.19.4",
         "hardhat-gas-reporter": "^1.0.8",
         "ncp": "^2.0.0",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -39,6 +39,6 @@
     "dependencies": {
         "@semaphore-protocol/utils": "4.7.2",
         "axios": "1.6.6",
-        "ethers": "6.11.0"
+        "ethers": "6.13.4"
     }
 }

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -58,11 +58,11 @@ export default class SemaphoreEthers {
             options.address ??= address
             options.startBlock ??= startBlock
         } else {
-            if (options.address === undefined) {
-                throw new Error(`Network '${networkOrEthereumURL}' needs a Semaphore contract address`)
-            }
-
             options.startBlock ??= 0
+        }
+
+        if (options.address === undefined) {
+            throw new Error(`Network '${networkOrEthereumURL}' needs a Semaphore contract address`)
         }
 
         let provider: Provider

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -42,7 +42,7 @@
     "dependencies": {
         "@nomicfoundation/hardhat-ethers": "^3.0.0",
         "@semaphore-protocol/contracts": "4.7.2",
-        "ethers": "^6.4.0",
+        "ethers": "^6.13.4",
         "hardhat-dependency-compiler": "^1.1.3"
     }
 }

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -54,7 +54,7 @@
         "@semaphore-protocol/utils": "4.7.2",
         "@zk-kit/artifacts": "1.8.0",
         "@zk-kit/utils": "1.2.1",
-        "ethers": "6.10.0",
+        "ethers": "6.13.4",
         "snarkjs": "0.7.4"
     }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -54,6 +54,6 @@
         "rollup-plugin-cleanup": "^3.2.1"
     },
     "dependencies": {
-        "ethers": "^6.11.1"
+        "ethers": "^6.13.4"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,13 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"@adraffy/ens-normalize@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@adraffy/ens-normalize@npm:1.10.0"
-  checksum: 10/5cdb5d2a9c9f8c0a71a7bb830967da0069cae1f1235cd41ae11147e4000f368f6958386e622cd4d52bf45c1ed3f8275056b387cba28902b83354e40ff323ecde
-  languageName: node
-  linkType: hard
-
 "@adraffy/ens-normalize@npm:1.10.1":
   version: 1.10.1
   resolution: "@adraffy/ens-normalize@npm:1.10.1"
@@ -7354,7 +7347,7 @@ __metadata:
     eslint-config-airbnb-typescript: "npm:^17.1.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import: "npm:^2.29.1"
-    ethers: "npm:^6.4.0"
+    ethers: "npm:^6.13.4"
     hardhat: "npm:^2.20.1"
     hardhat-gas-reporter: "npm:^1.0.8"
     prettier: "npm:^3.2.5"
@@ -7439,7 +7432,7 @@ __metadata:
     "@rollup/plugin-typescript": "npm:^11.1.6"
     "@semaphore-protocol/utils": "npm:4.7.2"
     axios: "npm:1.6.6"
-    ethers: "npm:6.11.0"
+    ethers: "npm:6.13.4"
     rimraf: "npm:^5.0.5"
     rollup: "npm:^4.12.0"
     rollup-plugin-cleanup: "npm:^3.2.1"
@@ -7467,7 +7460,7 @@ __metadata:
     "@nomicfoundation/hardhat-ethers": "npm:^3.0.0"
     "@rollup/plugin-typescript": "npm:^11.1.6"
     "@semaphore-protocol/contracts": "npm:4.7.2"
-    ethers: "npm:^6.4.0"
+    ethers: "npm:^6.13.4"
     hardhat: "npm:^2.19.4"
     hardhat-dependency-compiler: "npm:^1.1.3"
     rimraf: "npm:^5.0.5"
@@ -7505,7 +7498,7 @@ __metadata:
     "@types/snarkjs": "npm:^0"
     "@zk-kit/artifacts": "npm:1.8.0"
     "@zk-kit/utils": "npm:1.2.1"
-    ethers: "npm:6.10.0"
+    ethers: "npm:6.13.4"
     rimraf: "npm:^5.0.5"
     rollup: "npm:^4.12.0"
     rollup-plugin-cleanup: "npm:^3.2.1"
@@ -7522,7 +7515,7 @@ __metadata:
   dependencies:
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-typescript": "npm:^11.1.6"
-    ethers: "npm:^6.11.1"
+    ethers: "npm:^6.13.4"
     rimraf: "npm:^5.0.5"
     rollup: "npm:^4.12.0"
     rollup-plugin-cleanup: "npm:^3.2.1"
@@ -8690,10 +8683,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.15.13":
-  version: 18.15.13
-  resolution: "@types/node@npm:18.15.13"
-  checksum: 10/b9bbe923573797ef7c5fd2641a6793489e25d9369c32aeadcaa5c7c175c85b42eb12d6fe173f6781ab6f42eaa1ebd9576a419eeaa2a1ec810094adb8adaa9a54
+"@types/node@npm:22.7.5":
+  version: 22.7.5
+  resolution: "@types/node@npm:22.7.5"
+  dependencies:
+    undici-types: "npm:~6.19.2"
+  checksum: 10/e8ba102f8c1aa7623787d625389be68d64e54fcbb76d41f6c2c64e8cf4c9f4a2370e7ef5e5f1732f3c57529d3d26afdcb2edc0101c5e413a79081449825c57ac
   languageName: node
   linkType: hard
 
@@ -14852,33 +14847,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:6.10.0":
-  version: 6.10.0
-  resolution: "ethers@npm:6.10.0"
-  dependencies:
-    "@adraffy/ens-normalize": "npm:1.10.0"
-    "@noble/curves": "npm:1.2.0"
-    "@noble/hashes": "npm:1.3.2"
-    "@types/node": "npm:18.15.13"
-    aes-js: "npm:4.0.0-beta.5"
-    tslib: "npm:2.4.0"
-    ws: "npm:8.5.0"
-  checksum: 10/04fdd3f76ea93a8b45b2fe4d9c8e2bd0d688823faba672897dd19cc3303c202a166902fe6058004562f13aaecf9f77a9f70ff113f995e94107efef2457b016dd
-  languageName: node
-  linkType: hard
-
-"ethers@npm:6.11.0":
-  version: 6.11.0
-  resolution: "ethers@npm:6.11.0"
+"ethers@npm:6.13.4, ethers@npm:^6.13.4":
+  version: 6.13.4
+  resolution: "ethers@npm:6.13.4"
   dependencies:
     "@adraffy/ens-normalize": "npm:1.10.1"
     "@noble/curves": "npm:1.2.0"
     "@noble/hashes": "npm:1.3.2"
-    "@types/node": "npm:18.15.13"
+    "@types/node": "npm:22.7.5"
     aes-js: "npm:4.0.0-beta.5"
-    tslib: "npm:2.4.0"
-    ws: "npm:8.5.0"
-  checksum: 10/c6e5964ceabf2d289f8ae5b16e634995375457a8c5b814ea54799b5a3c951668465adb9b6dda3aea559d9c4fe3faa8297a38651853b54a53de9448663a908f12
+    tslib: "npm:2.7.0"
+    ws: "npm:8.17.1"
+  checksum: 10/221192fed93f6b0553f3e5e72bfd667d676220577d34ff854f677e955d6f608e60636a9c08b5d54039c532a9b9b7056384f0d7019eb6e111d53175806f896ac6
   languageName: node
   linkType: hard
 
@@ -14917,21 +14897,6 @@ __metadata:
     "@ethersproject/web": "npm:5.7.1"
     "@ethersproject/wordlists": "npm:5.7.0"
   checksum: 10/227dfa88a2547c799c0c3c9e92e5e246dd11342f4b495198b3ae7c942d5bf81d3970fcef3fbac974a9125d62939b2d94f3c0458464e702209b839a8e6e615028
-  languageName: node
-  linkType: hard
-
-"ethers@npm:^6.11.1, ethers@npm:^6.4.0":
-  version: 6.12.1
-  resolution: "ethers@npm:6.12.1"
-  dependencies:
-    "@adraffy/ens-normalize": "npm:1.10.1"
-    "@noble/curves": "npm:1.2.0"
-    "@noble/hashes": "npm:1.3.2"
-    "@types/node": "npm:18.15.13"
-    aes-js: "npm:4.0.0-beta.5"
-    tslib: "npm:2.4.0"
-    ws: "npm:8.5.0"
-  checksum: 10/2995766164292b531499764d319d753b1f4e1cd7ddb4f26c6557a26e42947d5642a4b3bbeace0b8bb398b909dc22fafa4f52d5190a9bb8180bebf2dd3d4d48a9
   languageName: node
   linkType: hard
 
@@ -21305,7 +21270,7 @@ __metadata:
     eslint-config-airbnb-typescript: "npm:^17.1.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import: "npm:^2.29.1"
-    ethers: "npm:^6.4.0"
+    ethers: "npm:^6.13.4"
     hardhat: "npm:^2.20.1"
     hardhat-gas-reporter: "npm:^1.0.8"
     prettier: "npm:^3.2.5"
@@ -21331,7 +21296,7 @@ __metadata:
     dotenv: "npm:^16.4.5"
     eslint: "npm:^8"
     eslint-config-next: "npm:14.1.0"
-    ethers: "npm:^6.11.1"
+    ethers: "npm:^6.13.4"
     next: "npm:14.1.0"
     next-pwa: "npm:^5.6.0"
     react: "npm:^18"
@@ -21368,7 +21333,7 @@ __metadata:
     eslint-config-airbnb-typescript: "npm:^17.1.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import: "npm:^2.29.1"
-    ethers: "npm:^6.4.0"
+    ethers: "npm:^6.13.4"
     hardhat: "npm:^2.20.1"
     hardhat-gas-reporter: "npm:^1.0.8"
     prettier: "npm:^3.2.5"
@@ -21394,7 +21359,7 @@ __metadata:
     dotenv: "npm:^16.4.5"
     eslint: "npm:^8"
     eslint-config-next: "npm:14.1.0"
-    ethers: "npm:^6.11.1"
+    ethers: "npm:^6.13.4"
     next: "npm:14.1.0"
     next-pwa: "npm:^5.6.0"
     react: "npm:^18"
@@ -25857,7 +25822,7 @@ __metadata:
     "@types/node": "npm:^20.10.7"
     "@zk-kit/lean-imt.sol": "npm:2.0.0"
     chai: "npm:^4.2.0"
-    ethers: "npm:^6.4.0"
+    ethers: "npm:^6.13.4"
     hardhat: "npm:^2.19.4"
     hardhat-gas-reporter: "npm:^1.0.8"
     ncp: "npm:^2.0.0"
@@ -27935,6 +27900,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.7.0":
+  version: 2.7.0
+  resolution: "tslib@npm:2.7.0"
+  checksum: 10/9a5b47ddac65874fa011c20ff76db69f97cf90c78cff5934799ab8894a5342db2d17b4e7613a087046bc1d133d21547ddff87ac558abeec31ffa929c88b7fce6
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.8.1, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
@@ -28322,6 +28294,13 @@ __metadata:
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
   checksum: 10/0097779d94bc0fd26f0418b3a05472410408877279141ded2bd449167be1aed7ea5b76f756562cb3586a07f251b90799bab22d9019ceba49c037c76445f7cddd
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.19.2":
+  version: 6.19.8
+  resolution: "undici-types@npm:6.19.8"
+  checksum: 10/cf0b48ed4fc99baf56584afa91aaffa5010c268b8842f62e02f752df209e3dea138b372a60a963b3b2576ed932f32329ce7ddb9cb5f27a6c83040d8cd74b7a70
   languageName: node
   linkType: hard
 
@@ -29762,18 +29741,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.5.0":
-  version: 8.5.0
-  resolution: "ws@npm:8.5.0"
+"ws@npm:8.17.1":
+  version: 8.17.1
+  resolution: "ws@npm:8.17.1"
   peerDependencies:
     bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
+    utf-8-validate: ">=5.0.2"
   peerDependenciesMeta:
     bufferutil:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/f0ee700970a0bf925b1ec213ca3691e84fb8b435a91461fe3caf52f58c6cec57c99ed5890fbf6978824c932641932019aafc55d864cad38ac32577496efd5d3a
+  checksum: 10/4264ae92c0b3e59c7e309001e93079b26937aab181835fb7af79f906b22cd33b6196d96556dafb4e985742dd401e99139572242e9847661fdbc96556b9e6902d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Update ethers version to resolve ws security issue (CVE-2024-37890). 
- Move contract address check outside of branch statement so Typescript can see.
- Add build instructions to setup to resolve 'Cannot find module '@semaphore-protocol/...' when running tests for the first time.

## Related Issue

Resolves https://github.com/semaphore-protocol/semaphore/issues/920

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
    - Relying on existing tests, See https://github.com/semaphore-protocol/semaphore/issues/920#issuecomment-2537330984 for some additional work that could help prevent this in the future.
-   [x] New and existing unit tests pass locally with my changes
