### PR TITLE
docs: fix broken link and typo correction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Pull requests are great if you want to add a feature or fix a bug. Here's a quic
 
 3. Add a test for your change. Only refactoring and documentation changes require no new tests.
 
-4. Make sure to check out the [Style Guide](/CONTRIBUTING#style-guide) and ensure that your code complies with the rules.
+4. Make sure to check out the [Style Guide](/CONTRIBUTING.md#style-guide) and ensure that your code complies with the rules.
 
 5. Make the test pass.
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Install the dependencies:
 cd semaphore && yarn
 ```
 
-And build the repositiory:
+And build the repository:
 
 ```bash
 yarn build


### PR DESCRIPTION
This PR fixes minor typographical errors in the `README.md` and `CONTRIBUTING.md` files.

- **README.md:** Corrected "repositiory" to "repository".
- **CONTRIBUTING.md:** Fixed broken redirect link to the Style Guide by updating the relative path to include the `.md` extension.

No new functionality has been added or removed. These changes improve documentation clarity and maintainability.

## Related Issue(s)

N/A

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have run `yarn format` and `yarn lint` without getting any errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.