### PR TITLE
chore(cli-template-contracts-foundry): add prepublish script

### DIFF
--- a/packages/cli-template-contracts-foundry/.editorconfig
+++ b/packages/cli-template-contracts-foundry/.editorconfig
@@ -1,0 +1,13 @@
+#root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/cli-template-contracts-foundry/.prettierignore
+++ b/packages/cli-template-contracts-foundry/.prettierignore
@@ -1,0 +1,30 @@
+# dependencies
+node_modules
+package-lock.json
+yarn.lock
+.yarn
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# testing
+coverage
+coverage.json
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Foundry artifact
+cache/
+out/
+
+# artifact for deploying on local Anvil node
+**/31337

--- a/packages/cli-template-contracts-foundry/package.json
+++ b/packages/cli-template-contracts-foundry/package.json
@@ -23,7 +23,8 @@
         "lint": "yarn solhint \"{script,src,test}/**/*.sol\"",
         "prettier": "prettier -c \"**/*.{json,md,svg,yml,sol}\"",
         "prettier:write": "prettier -w \"**/*.{json,md,svg,yml,sol}\"",
-        "check": "yarn test & yarn lint & yarn prettier"
+        "check": "yarn test & yarn lint & yarn prettier",
+        "prepublish": "tar -czf files.tgz .gitignore .yarn .yarnrc.yml"
     },
     "files": [
         "src",
@@ -32,10 +33,12 @@
         "package.json",
         "foundry.toml",
         "remappings.txt",
-        "README.md"
+        "README.md",
+        "files.tgz",
+        ".editorconfig",
+        ".env.example",
+        ".prettierignore",
+        ".prettierrc.json"
     ],
-    "publishConfig": {
-        "access": "public"
-    },
     "packageManager": "yarn@4.1.0"
 }

--- a/typedoc.js
+++ b/typedoc.js
@@ -8,6 +8,7 @@ const EXCLUDE_PKGS = [
     "cli-template-contracts-hardhat",
     "cli-template-monorepo-ethers",
     "cli-template-monorepo-subgraph",
+    "cli-template-contracts-foundry",
     "contracts",
     "core",
     "hardhat"


### PR DESCRIPTION
## Description

This PR: 

- adds `prepublish` script to publish foundry template.
- adds `.editorconfig` and `.prettierignore` file to foundry template.
- adds files that should also be exported in the foundry template.
- updates typedoc.js file to add `cli-template-contracts-foundry`.

## Related Issue(s)

Re https://github.com/semaphore-protocol/semaphore/issues/926

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
