### PR TITLE
fix: Replace map with forEach to avoid unnecessary array creation

### DIFF
--- a/scripts/clean-packages.ts
+++ b/scripts/clean-packages.ts
@@ -10,7 +10,7 @@ async function main() {
         .filter((file) => file.isDirectory())
         .map((dir) => dir.name)
 
-    folders.map((app) => gitIgnored.map((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })))
+    folders.forEach((app) => gitIgnored.forEach((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })))
 
     rmSync(`${folderName}/circuit/main`, { recursive: true, force: true })
     rmSync(`${folderName}/circuit/test`, { recursive: true, force: true })


### PR DESCRIPTION
## Description

`map` was used instead of `forEach` in the code. Since `map` creates a new array that isn't being used, it can be misleading and is considered an anti-pattern.

I've replaced it with `forEach` to make the intent clearer and avoid unnecessary overhead.

## Checklist

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
