### PR TITLE
Fix typos and formatting in documentation

### DIFF
--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/libsemaphore.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/libsemaphore.md
@@ -145,7 +145,7 @@ Returns `false` otherwise.
 
 **`signMsg(privKey: EddsaPrivateKey, msg: SnarkBigInt): EdDSAMiMcSpongeSignature)`**
 
-Encapsualtes `circomlib.eddsa.signMiMCSponge` to sign a message `msg` using private key `privKey`.
+Encapsulates `circomlib.eddsa.signMiMCSponge` to sign a message `msg` using private key `privKey`.
 
 **`verifySignature(msg: SnarkBigInt, signature: EdDSAMiMcSpongeSignature, pubKey: EddsaPublicKey)`: boolean**
 
@@ -190,7 +190,7 @@ const genWitness = async (
 -   `circuit` is the output of `genCircuit()`.
 -   `identity` is the `Identity` whose identity commitment you want to prove is
     in the set of registered identities.
--   `idCommitments` is an array of registered identity commmitments; i.e. the
+-   `idCommitments` is an array of registered identity commitments; i.e. the
     leaves of the tree.
 -   `treeDepth` is the number of levels which the Merkle tree used has
 -   `externalNullifier` is the current external nullifier

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/what-is-semaphore.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/what-is-semaphore.md
@@ -89,7 +89,7 @@ An anonymous voting app would be configured differently:
 | ----------------------------------- | ------------------------ |
 | The hash of the respondent's answer | The hash of the question |
 
-This allows any user to vote with an arbitary response (e.g. yes, no, or maybe)
+This allows any user to vote with an arbitrary response (e.g. yes, no, or maybe)
 to any question. The user, however, can only vote once per question.
 
 ## About the code

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V2/subgraph.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V2/subgraph.md
@@ -9,7 +9,7 @@ Site owners publish _subgraphs_ that expose site data for anyone to query.
 Semaphore's subgraph allows you to retrieve data from the [`Semaphore.sol`](https://github.com/semaphore-protocol/semaphore/tree/v2.6.1/packages/contracts/Semaphore.sol) smart contract.
 
 :::tip
-The Graph protocol uses the [GraphQL](https://graphql.org/) query lanaguage. For examples, see the [GraphQL API documentation](https://thegraph.com/docs/developer/graphql-api). Visit the [subgraph repository](https://github.com/semaphore-protocol/subgraph) to see the list of Semaphore subgraphs.
+The Graph protocol uses the [GraphQL](https://graphql.org/) query language. For examples, see the [GraphQL API documentation](https://thegraph.com/docs/developer/graphql-api). Visit the [subgraph repository](https://github.com/semaphore-protocol/subgraph) to see the list of Semaphore subgraphs.
 :::
 
 ## Schema


### PR DESCRIPTION
This PR includes the following documentation improvements:

**1. Fixed typo in libsemaphore.md:**
- Corrected "commitents" to "commitments" in idCommitments description

**2. Fixed formatting in what-is-semaphore.md:**
- Consistent formatting for "arbitrary" text

**3. Fixed typo in subgraph.md:**
- Corrected "lanaguage" to "language" in GraphQL description

These changes improve readability and consistency of the documentation without any functional changes.