### PR TITLE
fix broken issues links in README files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We're really glad you're reading this, because we need volunteer developers to h
 
 ## Issues
 
-The best way to contribute to our projects is by opening a [new issue](https://github.com/semaphore-protocol/semaphore/issues/new/choose) or tackling one of the issues listed [here](https://github.com/semaphore-protocol/semaphore/contribute).
+The best way to contribute to our projects is by opening a [new issue](https://github.com/semaphore-protocol/semaphore/issues/new/choose) or tackling one of the issues listed [here](https://github.com/semaphore-protocol/semaphore/issues).
 
 ## Pull Requests
 

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -30,7 +30,7 @@
             🤝 Code of conduct
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/semaphore-protocol/semaphore/contribute">
+        <a href="https://github.com/semaphore-protocol/semaphore/issues">
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -36,7 +36,7 @@
             🤝 Code of conduct
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/semaphore-protocol/semaphore/contribute">
+        <a href="https://github.com/semaphore-protocol/semaphore/issues">
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>


### PR DESCRIPTION
## Description

Updated broken links to the issues page across multiple README files:

- Changed `/contribute` to `/issues` in CONTRIBUTING.md
- Updated link in `apps/website/README.md` to point to the correct issues page
- Fixed link in `packages/cli/README.md` to properly direct to issues section

These changes ensure users are directed to the correct issues page when looking to contribute to the project.

## Related Issue(s)
- Fixes broken navigation to issues page
- Improves documentation accessibility

## Checklist
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] Documentation has been updated
