### PR TITLE
docs: add specification document link to website and docs

### DIFF
--- a/apps/docs/versioned_docs/version-V4/what-is-semaphore.md
+++ b/apps/docs/versioned_docs/version-V4/what-is-semaphore.md
@@ -11,6 +11,8 @@ slug: /
 Additionally, it provides a simple mechanism to prevent double-signaling.
 Use cases include private voting, whistleblowing, anonymous DAOs and mixers.
 
+For in-depth technical details about Semaphore, refer to the [Semaphore V4 Specification](https://github.com/zkspecs/zkspecs/blob/main/specs/3/README.md).
+
 ## Features
 
 With Semaphore, you can allow your users to do the following:

--- a/apps/website/src/data/articles.json
+++ b/apps/website/src/data/articles.json
@@ -47,5 +47,12 @@
         "date": "2024-12-09",
         "authors": ["glasswing"],
         "url": "https://mirror.xyz/0xBE98D44c29D179588b7E717Db8898529e5cD770F/5Xlv1jzwJKfKgP-m257kjivBlUIM_cwTzsmpf9F0Su8"
+    },
+    {
+        "title": "Semaphore V4 Specification",
+        "minRead": 10,
+        "date": "2025-03-01",
+        "authors": ["Semaphore Team"],
+        "url": "https://github.com/zkspecs/zkspecs/blob/main/specs/3/README.md"
     }
 ]


### PR DESCRIPTION
## Description

This PR adds the Semaphore V4 Specification document to the website and docs.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.
