### PR TITLE
chore: replace `map()` with `forEach()` for better clarity

### DIFF
--- a/scripts/clean-apps.ts
+++ b/scripts/clean-apps.ts
@@ -20,7 +20,7 @@ async function main() {
         .filter((file) => file.isDirectory())
         .map((dir) => dir.name)
 
-    folders.map((app) => gitIgnored.map((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })))
+    folders.forEach((app) => gitIgnored.forEach((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })))
 }
 
 main()


### PR DESCRIPTION
## Description

`map()` was being used to iterate over arrays, but the result of the map call was never used.
this is inefficient because `map()` is designed to create a new array, which is unnecessary in this case.
i’ve replaced it with `forEach()` to make the code more clear and performant, as we only need to iterate over the array and don't require the resulting array.

## Checklist
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
