### PR TITLE
fix: unnecessary use of `map()` for side effects

### DIFF
--- a/scripts/clean-apps.ts
+++ b/scripts/clean-apps.ts
@@ -20,7 +20,11 @@ async function main() {
         .filter((file) => file.isDirectory())
         .map((dir) => dir.name)
 
-    folders.map((app) => gitIgnored.map((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })))
+    folders.forEach((app) => {
+        gitIgnored.forEach((f) => {
+            rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true })
+        })
+    })
 }
 
 main()


### PR DESCRIPTION
## Description

replaced the `map(...).map(...)` chain with `forEach(...).forEach(...)` as the result of `map` wasn't being used

## Checklist

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
