### PR TITLE
chore: fix typos

### DIFF
--- a/types/ffjavascript/index.d.ts
+++ b/types/ffjavascript/index.d.ts
@@ -269,7 +269,7 @@ declare module "ffjavascript" {
 
         add(...args: any[]): void
 
-        computeVanishingPolinomial(...args: any[]): void
+        computeVanishingPolynomial(...args: any[]): void
 
         div(...args: any[]): void
 


### PR DESCRIPTION
## Description

This PR fixes a typo in the function name from `computeVanishingPolinomial` to `computeVanishingPolynomial` in the types/fjavascript/index.d.ts file. This change ensures consistency in spelling and improves code readability.

<!-- Fixes # -->

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run `yarn format` and `yarn lint` without getting any errors