### PR TITLE
Fix broken link to Semaphore specification in documentation

### DIFF
--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/what-is-semaphore.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/what-is-semaphore.md
@@ -25,7 +25,7 @@ if these proofs are valid.
 
 For a formal description of Semaphore and its underlying cryptographic
 mechanisms, also see this document
-[here](https://github.com/appliedzkp/semaphore/tree/master/spec).
+[here](https://docs.semaphore.pse.dev/).
 
 Semaphore is designed for smart contract and dApp developers, not end users.
 Developers should abstract its features away in order to provide user-friendly


### PR DESCRIPTION
Replaced the outdated link to the Semaphore specification (https://github.com/appliedzkp/semaphore/tree/master/spec) with the current official documentation link (https://docs.semaphore.pse.dev/) in both the English and Spanish V1 documentation files. This ensures users are directed to the up-to-date protocol specification and resources.