### PR TITLE
fix: optimize BigInt usage in hash function

### DIFF
--- a/packages/proof/src/hash.ts
+++ b/packages/proof/src/hash.ts
@@ -9,5 +9,5 @@ import { NumericString } from "snarkjs"
  * @returns The message digest.
  */
 export default function hash(message: BigNumberish): NumericString {
-    return (BigInt(keccak256(toBeHex(message, 32))) >> BigInt(8)).toString()
+    return (BigInt(keccak256(toBeHex(message, 32))) >> 8n).toString()
 }


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Replace BigInt(8) with 8n literal in bit shift operation to improve performance by avoiding unnecessary BigInt object creation.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


