### PR TITLE
fix: improve error handling in toBigInt function

### DIFF
--- a/packages/proof/src/to-bigint.ts
+++ b/packages/proof/src/to-bigint.ts
@@ -15,6 +15,6 @@ export default function toBigInt(value: BigNumberish | Uint8Array | string): big
             return _toBigInt(encodeBytes32String(value))
         }
 
-        throw TypeError(error.message)
+        throw TypeError(error?.message || error.toString())
     }
 }

--- a/packages/proof/src/to-bigint.ts
+++ b/packages/proof/src/to-bigint.ts
@@ -15,6 +15,6 @@ export default function toBigInt(value: BigNumberish | Uint8Array | string): big
             return _toBigInt(encodeBytes32String(value))
         }
 
-        throw TypeError(error?.message || error.toString())
+        throw TypeError(error instanceof Error ? error.message : error.toString())
     }
 }


### PR DESCRIPTION
Fix TypeError when error.message is undefined by using optional chaining
and fallback to error.toString() for safer error handling.