### PR TITLE
fix(website): replace invalid alignment values and add missing units  

### DIFF
--- a/apps/website/src/app/build/page.tsx
+++ b/apps/website/src/app/build/page.tsx
@@ -98,7 +98,7 @@ export default function Build() {
                     mb={{ base: "120px", xl: "109px" }}
                     w={{ base: "auto", xl: "445px" }}
                 >
-                    <VStack alignItems="left">
+                    <VStack alignItems="start">
                         <Text fontSize={{ base: "30px", md: "44px" }} fontWeight="500">
                             Contribute to Semaphore
                         </Text>
@@ -106,7 +106,7 @@ export default function Build() {
                             Semaphore is open source with dozens of community contributors. You can propose improvements
                             to the protocol or take good first issues to get started.
                         </Text>
-                        <VStack mt="40px" alignItems="left">
+                        <VStack mt="40px" alignItems="start">
                             {linksInfo.map((linkInfo) => (
                                 <Link
                                     display="flex"

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -119,11 +119,11 @@ export default function Home() {
                         <VStack spacing="16">
                             <Stack
                                 direction={{ base: "column", md: "row" }}
-                                align="top"
+                                align="start"
                                 justify="space-between"
                                 spacing="16"
                             >
-                                <HStack flex="1" align="top" spacing="6">
+                                <HStack flex="1" align="start" spacing="6">
                                     <Heading
                                         fontSize={{ base: "30px", md: "38px" }}
                                         color="#1E46F2"
@@ -144,7 +144,7 @@ export default function Home() {
                                         </Text>
                                     </VStack>
                                 </HStack>
-                                <HStack flex="1" align="top" spacing="6">
+                                <HStack flex="1" align="start" spacing="6">
                                     <Heading
                                         fontSize={{ base: "30px", md: "38px" }}
                                         color="#1E46F2"
@@ -169,11 +169,11 @@ export default function Home() {
                             </Stack>
                             <Stack
                                 direction={{ base: "column", md: "row" }}
-                                align="top"
+                                align="start"
                                 justify="space-between"
                                 spacing="16"
                             >
-                                <HStack flex="1" align="top" spacing="6">
+                                <HStack flex="1" align="start" spacing="6">
                                     <Heading
                                         fontSize={{ base: "30px", md: "38px" }}
                                         color="#1E46F2"
@@ -195,7 +195,7 @@ export default function Home() {
                                         </Text>
                                     </VStack>
                                 </HStack>
-                                <HStack flex="1" align="top" spacing="6">
+                                <HStack flex="1" align="start" spacing="6">
                                     <Heading
                                         fontSize={{ base: "30px", md: "38px" }}
                                         color="#1E46F2"

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -237,7 +237,7 @@ export default function Home() {
                     </VStack>
                 </VStack>
 
-                <VStack maxW="650" align="center" spacing="8">
+                <VStack maxW="650px" align="center" spacing="8">
                     <Heading fontSize={{ base: "30px", md: "44px" }}>Join the Semaphore community</Heading>
                     <Text fontSize={{ base: "16px", md: "18px" }} textAlign="center">
                         Ask questions, suggest ideas, stay up-to-date, and meet other people building privacy

--- a/apps/website/src/components/Carousel.tsx
+++ b/apps/website/src/components/Carousel.tsx
@@ -141,7 +141,7 @@ export default function Carousel({ title, sizes, type, ...props }: CarouselProps
                         />
                     </HStack>
 
-                    <HStack flex="1" justify="right" fontSize="12px">
+                    <HStack flex="1" justify="end" fontSize="12px">
                         <Link
                             as={NextLink}
                             href="/projects"

--- a/apps/website/src/components/InfoCard.tsx
+++ b/apps/website/src/components/InfoCard.tsx
@@ -23,7 +23,7 @@ export default function InfoCard({ texts }: InfoCardProps) {
             height={{ base: "auto", md: "474px" }}
         >
             <CardBody padding="0">
-                <VStack align="start" spacing="10" maxH="500" overflowY="auto">
+                <VStack align="start" spacing="10" maxH="500px" overflowY="auto">
                     {texts.map((text) => (
                         <VStack key={text.title} align="start">
                             <Heading textAlign="left" fontSize={{ base: "20px", md: "24px" }}>


### PR DESCRIPTION
- Replaced invalid `left`/`top`/`right` props with valid `start`/`end` for Chakra UI alignment.  

- Added missing `px` units where needed.  

Updated affected UI components (`page.tsx`, `Carousel.tsx`, `InfoCard.tsx`) for consistent styling and proper rendering.  
