### PR TITLE
Add safe fallback to `decodeMessage` to prevent crashes on invalid bytes32

### DIFF
--- a/packages/utils/src/decode-message.ts
+++ b/packages/utils/src/decode-message.ts
@@ -12,6 +12,12 @@ import { toBeHex } from "ethers/utils"
  * @param message The Semaphore message as a bigint.
  * @returns The Semaphore message as a text.
  */
-export default function decodeMessage(message: BigNumberish) {
-    return decodeBytes32String(toBeHex(message, 32))
+export default function decodeMessage(message: BigNumberish): string {
+    const hex = toBeHex(message, 32)
+
+    try {
+        return decodeBytes32String(hex)
+    } catch {
+        return hex
+    }
 }

--- a/packages/utils/tests/index.test.ts
+++ b/packages/utils/tests/index.test.ts
@@ -56,5 +56,11 @@ describe("Utils", () => {
 
             expect(decodedMessage).toBe(message)
         })
+
+        it("Should return hex if message is not a valid bytes32 string", () => {
+            const hex = "0x66fdd5e25ef9ddb305ba3c2aae1856ab9c6f2979000000000000000000000000"
+            const result = decodeMessage(hex)
+            expect(result).toBe(hex)
+        })
     })
 })


### PR DESCRIPTION


## Description

Fixes a potential crash in `@semaphore-protocol/utils` when `decodeMessage` receives non-string bytes32 values (like addresses, hashes, or arbitrary uint256).

## Problem

The `decodeBytes32String` function in ethers v6 throws an exception when attempting to decode invalid UTF-8 sequences or non-string bytes32 values. This could cause UI/CLI applications to crash unexpectedly.

## Solution

- Added try-catch wrapper around `decodeBytes32String` call
- Returns hex representation as fallback when decoding fails
- Maintains backward compatibility for valid string inputs
- Added test coverage for invalid bytes32 handling

