### PR TITLE
tests: call functions in .rejects assertions so expect receives promises

### DIFF
--- a/packages/proof/tests/index.test.ts
+++ b/packages/proof/tests/index.test.ts
@@ -28,7 +28,7 @@ describe("Proof", () => {
 
             const fun = () => generateProof(identity, group, message, scope, 33)
 
-            await expect(fun).rejects.toThrow("tree depth must be")
+            await expect(fun()).rejects.toThrow("tree depth must be")
         })
 
         it("Should not generate Semaphore proofs if the identity is not part of the group", async () => {
@@ -36,7 +36,7 @@ describe("Proof", () => {
 
             const fun = () => generateProof(identity, group, message, scope, treeDepth)
 
-            await expect(fun).rejects.toThrow("does not exist")
+            await expect(fun()).rejects.toThrow("does not exist")
         })
 
         it("Should generate a Semaphore proof", async () => {
@@ -80,7 +80,7 @@ describe("Proof", () => {
 
             const fun = () => generateProof(identity, group, message, scope, undefined, "hello" as any)
 
-            await expect(fun).rejects.toThrow("is not an object")
+            await expect(fun()).rejects.toThrow("is not an object")
         })
 
         it("Should throw an error because the message value is incorrect", async () => {
@@ -88,7 +88,7 @@ describe("Proof", () => {
 
             const fun = () => generateProof(identity, group, Number.MAX_VALUE, scope, treeDepth)
 
-            await expect(fun).rejects.toThrow("overflow")
+            await expect(fun()).rejects.toThrow("overflow")
         })
     })
 
@@ -100,7 +100,7 @@ describe("Proof", () => {
 
             const fun = () => verifyProof({ ...proof, merkleTreeDepth: 40 })
 
-            await expect(fun).rejects.toThrow("tree depth must be")
+            await expect(fun()).rejects.toThrow("tree depth must be")
         })
 
         it("Should return true if the proof is valid", async () => {


### PR DESCRIPTION
- Update packages/proof/tests/index.test.ts to use expect(fun()).rejects... instead of expect(fun).rejects... in five places.
- Ensures .rejects receives a Promise rather than a function.
- Adjusted the .rejects assertions in packages/proof/tests/index.test.ts so they now pass a Promise, not a function.