### PR TITLE
fix(data): skip members with zero identityCommitment

### DIFF
--- a/packages/data/src/subgraph.ts
+++ b/packages/data/src/subgraph.ts
@@ -122,7 +122,7 @@ export default class SemaphoreSubgraph {
                         admin
                         ${
                             members === true
-                                ? `members(orderBy: index) {
+                                ? `members(where: { identityCommitment_not: "0" }, orderBy: index) {
                             identityCommitment
                         }`
                                 : ""
@@ -186,7 +186,7 @@ export default class SemaphoreSubgraph {
                         admin
                         ${
                             members === true
-                                ? `members(orderBy: index) {
+                                ? `members(where: { identityCommitment_not: "0" }, orderBy: index) {
                             identityCommitment
                         }`
                                 : ""


### PR DESCRIPTION
## Description

Updated SemaphoreSubgraph queries to ignore members with identityCommitment equal to "0".
This prevents removed/invalid members from showing up in getGroup and getGroupMembers results.

Also added tests to make sure these members are filtered out and that the GraphQL query includes the proper where clause.

## Related Issue(s)

Closes ##858

## Other information

- Two new test cases added for getGroup and getGroupMembers.
- Verified the query filter is working as expected.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
