### PR TITLE
fix(data/ethers): correct MembersAdded map type to string[]

### DIFF
--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -208,7 +208,7 @@ export default class SemaphoreEthers {
 
         const membersAddedEvents = await getEvents(this._contract, "MembersAdded", [groupId], this._options.startBlock)
 
-        const membersAddedEventsMap = new Map<string, [string]>()
+        const membersAddedEventsMap = new Map<string, string[]>()
 
         for (const [, startIndex, identityCommitments] of membersAddedEvents) {
             membersAddedEventsMap.set(


### PR DESCRIPTION
- Change membersAddedEventsMap to Map<string, string[]> in packages/data/src/ethers.ts.
- Aligns type with actual stored values (string[]) and viem.ts logic.
- Improves type safety; no functional behavior changes.