### PR TITLE
chore(docs, contracts): fix typos across docs

### DIFF
--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/howitworks.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/howitworks.md
@@ -10,8 +10,8 @@ An identity is comprised of the following information:
 
 1. An [EdDSA](https://en.wikipedia.org/wiki/EdDSA) private key. Note that it is
    _not_ an Ethereum private key.
-2. An identity nullifier, whih is a random 32-byte value.
-3. An identity trapdoor, whih is a random 32-byte value.
+2. An identity nullifier, which is a random 32-byte value.
+3. An identity trapdoor, which is a random 32-byte value.
 
 An identity commitment is the Pedersen hash of:
 
@@ -121,7 +121,7 @@ authenticity of the signal and prevents front-running attacks.
 
 ## Cryptographic primitives
 
-Semaphore uses MiMC for the Merkle tree, Pedersen commmitments for the identity
+Semaphore uses MiMC for the Merkle tree, Pedersen commitments for the identity
 commitments, Blake2 for the nullifiers hash, and EdDSA for the signature.
 
 MiMC is a relatively new hash function. We use the recommended MiMC

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/libsemaphore.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/libsemaphore.md
@@ -145,7 +145,7 @@ Returns `false` otherwise.
 
 **`signMsg(privKey: EddsaPrivateKey, msg: SnarkBigInt): EdDSAMiMcSpongeSignature)`**
 
-Encapsualtes `circomlib.eddsa.signMiMCSponge` to sign a message `msg` using private key `privKey`.
+Encapsulates `circomlib.eddsa.signMiMCSponge` to sign a message `msg` using private key `privKey`.
 
 **`verifySignature(msg: SnarkBigInt, signature: EdDSAMiMcSpongeSignature, pubKey: EddsaPublicKey)`: boolean**
 
@@ -190,7 +190,7 @@ const genWitness = async (
 -   `circuit` is the output of `genCircuit()`.
 -   `identity` is the `Identity` whose identity commitment you want to prove is
     in the set of registered identities.
--   `idCommitments` is an array of registered identity commmitments; i.e. the
+-   `idCommitments` is an array of registered identity commitments; i.e. the
     leaves of the tree.
 -   `treeDepth` is the number of levels which the Merkle tree used has
 -   `externalNullifier` is the current external nullifier
@@ -204,7 +204,7 @@ It returns an object as such:
 -   `msg`: The hash of the external nullifier and the signal hash
 -   `signature`: The signature on the above msg.
 -   `tree`: The Merkle tree object after it has been updated with the identity commitment
--   `identityPath`: The Merkle path to the identity commmitment
+-   `identityPath`: The Merkle path to the identity commitment
 -   `identityPathIndex`: The leaf index of the identity commitment
 -   `identityPathElements`: The elements along the above Merkle path
 

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/what-is-semaphore.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V1/what-is-semaphore.md
@@ -89,13 +89,13 @@ An anonymous voting app would be configured differently:
 | ----------------------------------- | ------------------------ |
 | The hash of the respondent's answer | The hash of the question |
 
-This allows any user to vote with an arbitary response (e.g. yes, no, or maybe)
+This allows any user to vote with an arbitrary response (e.g. yes, no, or maybe)
 to any question. The user, however, can only vote once per question.
 
 ## About the code
 
 This repository contains the code for Semaphore's contracts written in
-Soliidty, and zk-SNARK circuits written in
+Solidity, and zk-SNARK circuits written in
 [circom](https://github.com/iden3/circom). It also contains Typescript code to
 execute tests.
 

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V2/guides/proofs.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V2/guides/proofs.md
@@ -87,7 +87,7 @@ To verify Semaphore proofs in your contract, import `SemaphoreCore` and pass the
 
 Remember to save the `nullifierHash` on-chain to avoid double-signaling.
 
-Alternatively, you can use an already deployed [`Semaphore`](https://github.com/semaphore-protocol/semaphore/tree/v2.6.1/packages/contracts/Semaphore.sol) contract and use its `verifiyProof` external function.
+Alternatively, you can use an already deployed [`Semaphore`](https://github.com/semaphore-protocol/semaphore/tree/v2.6.1/packages/contracts/Semaphore.sol) contract and use its `verifyProof` external function.
 
 ### Generate a Solidity-compatible proof
 

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V2/subgraph.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/version-V2/subgraph.md
@@ -9,7 +9,7 @@ Site owners publish _subgraphs_ that expose site data for anyone to query.
 Semaphore's subgraph allows you to retrieve data from the [`Semaphore.sol`](https://github.com/semaphore-protocol/semaphore/tree/v2.6.1/packages/contracts/Semaphore.sol) smart contract.
 
 :::tip
-The Graph protocol uses the [GraphQL](https://graphql.org/) query lanaguage. For examples, see the [GraphQL API documentation](https://thegraph.com/docs/developer/graphql-api). Visit the [subgraph repository](https://github.com/semaphore-protocol/subgraph) to see the list of Semaphore subgraphs.
+The Graph protocol uses the [GraphQL](https://graphql.org/) query language. For examples, see the [GraphQL API documentation](https://thegraph.com/docs/developer/graphql-api). Visit the [subgraph repository](https://github.com/semaphore-protocol/subgraph) to see the list of Semaphore subgraphs.
 :::
 
 ## Schema

--- a/apps/docs/versioned_docs/version-V4/trusted-setup.md
+++ b/apps/docs/versioned_docs/version-V4/trusted-setup.md
@@ -34,7 +34,7 @@ The [Semaphore circuit](https://github.com/semaphore-protocol/semaphore/blob/mai
 
 ### Transparency and Fairness
 
-We are committed to transparency on ceremony setup, execution, finalization, and later verification. Our primary goal is to **engage as many contributors as possible** to ensure the circuit is **secure** and **production-ready**. To this end, the ceremony is designed to _maximize contributor inclusion_, monitor & troubleshoot whenever is needed, _lower the entry barriers_, _making contributiong as effortless as possible_. A key step towards achieving these goals is running the ceremony w/ [p0tion](https://github.com/privacy-scaling-explorations/p0tion): an in-house developed, open-source, battle-tested tool that is fully equipped to meet our needs.
+We are committed to transparency on ceremony setup, execution, finalization, and later verification. Our primary goal is to **engage as many contributors as possible** to ensure the circuit is **secure** and **production-ready**. To this end, the ceremony is designed to _maximize contributor inclusion_, monitor & troubleshoot whenever is needed, _lower the entry barriers_, _making contributing as effortless as possible_. A key step towards achieving these goals is running the ceremony w/ [p0tion](https://github.com/privacy-scaling-explorations/p0tion): an in-house developed, open-source, battle-tested tool that is fully equipped to meet our needs.
 
 ### Ceremony Settings
 

--- a/packages/contracts/contracts/Semaphore.sol
+++ b/packages/contracts/contracts/Semaphore.sol
@@ -23,7 +23,7 @@ contract Semaphore is ISemaphore, SemaphoreGroups {
     uint256 public groupCounter;
 
     /// @dev Initializes the Semaphore verifier used to verify the user's ZK proofs.
-    /// @param _verifier: Semaphore verifier addresse.
+    /// @param _verifier: Semaphore verifier address.
     constructor(ISemaphoreVerifier _verifier) {
         verifier = _verifier;
     }

--- a/packages/contracts/contracts/base/SemaphoreGroups.sol
+++ b/packages/contracts/contracts/base/SemaphoreGroups.sol
@@ -6,7 +6,7 @@ import {InternalLeanIMT, LeanIMTData} from "@zk-kit/lean-imt.sol/InternalLeanIMT
 
 /// @title Semaphore groups contract.
 /// @dev This contract allows you to create groups, add, remove and update members.
-/// You can use getters to obtain informations about groups (root, depth, number of leaves).
+/// You can use getters to obtain information about groups (root, depth, number of leaves).
 abstract contract SemaphoreGroups is ISemaphoreGroups {
     using InternalLeanIMT for LeanIMTData;
 

--- a/packages/group/src/index.ts
+++ b/packages/group/src/index.ts
@@ -135,7 +135,7 @@ export class Group {
 
     /**
      * Enables the conversion of the group into a JSON string that
-     * can be re-used for future imports. This approach is beneficial for
+     * can be reused for future imports. This approach is beneficial for
      * large groups, as it avoids re-calculating the tree hashes.
      * @returns The stringified JSON of the group.
      */

--- a/types/ffjavascript/index.d.ts
+++ b/types/ffjavascript/index.d.ts
@@ -269,7 +269,7 @@ declare module "ffjavascript" {
 
         add(...args: any[]): void
 
-        computeVanishingPolinomial(...args: any[]): void
+        computeVanishingPolynomial(...args: any[]): void
 
         div(...args: any[]): void
 


### PR DESCRIPTION
- **Docs (i18n + guides + specs)**  
  - `whih` → `which`  
  - `commmitments` → `commitments`  
  - `Encapsualtes` → `Encapsulates`  
  - `arbitary` → `arbitrary`  
  - `Soliidty` → `Solidity`  
  - `verifiyProof` → `verifyProof`  
  - `lanaguage` → `language`  
  - `contributiong` → `contributing`  

- **Contracts**  
  - `addresse` → `address` (constructor param docstring)  
  - `informations` → `information`  

- **TypeScript**  
  - `re-used` → `reused` (comment in `Group`)  

- **Types**  
  - `computeVanishingPolinomial` → `computeVanishingPolynomial`  
