### PR TITLE
fix(data): strengthen event argument checks and add explicit type annotations

### DIFF
--- a/packages/data/src/viem.ts
+++ b/packages/data/src/viem.ts
@@ -257,7 +257,11 @@ export default class SemaphoreViem {
         const memberUpdatedEventsMap = new Map<string, [bigint, string]>()
 
         for (const event of memberUpdatedEvents) {
-            if (event.args.index && event.args.newIdentityCommitment && event.blockNumber) {
+            if (
+                event.args.index !== undefined &&
+                event.args.newIdentityCommitment !== undefined &&
+                event.blockNumber !== undefined
+            ) {
                 memberUpdatedEventsMap.set(event.args.index.toString(), [
                     event.blockNumber,
                     event.args.newIdentityCommitment.toString()
@@ -266,7 +270,7 @@ export default class SemaphoreViem {
         }
 
         for (const event of memberRemovedEvents) {
-            if (event.args.index && event.blockNumber) {
+            if (event.args.index !== undefined && event.blockNumber !== undefined) {
                 const groupUpdate = memberUpdatedEventsMap.get(event.args.index.toString())
 
                 if (!groupUpdate || (groupUpdate && groupUpdate[0] < event.blockNumber)) {
@@ -289,10 +293,10 @@ export default class SemaphoreViem {
         const membersAddedEventsMap = new Map<string, string[]>()
 
         for (const event of membersAddedEvents) {
-            if (event.args.startIndex && event.args.identityCommitments) {
+            if (event.args.startIndex !== undefined && Array.isArray(event.args.identityCommitments)) {
                 membersAddedEventsMap.set(
                     event.args.startIndex.toString(),
-                    event.args.identityCommitments.map((i) => i.toString())
+                    event.args.identityCommitments.map((i: string) => i.toString())
                 )
             }
         }
@@ -324,7 +328,7 @@ export default class SemaphoreViem {
                 const currentIndex = index // Create a closure to capture the current index value
                 const event = memberAddedEvents.find((e) => Number(e.args.index) === currentIndex)
 
-                if (event && event.args.identityCommitment) {
+                if (event && event.args.identityCommitment !== undefined) {
                     members.push(event.args.identityCommitment.toString())
                 }
 


### PR DESCRIPTION
- Replaced truthy checks with explicit guards against `undefined`/`null` for `index`, `startIndex`, `blockNumber`, `newIdentityCommitment`, and `identityCommitment`.
- Added explicit type annotation in `.map((i) => i.toString())` to remove implicit `any`.