### PR TITLE
docs: fix incorrect default value in chunkArray JSDoc

### DIFF
--- a/apps/website/src/utils/chunkArray.ts
+++ b/apps/website/src/utils/chunkArray.ts
@@ -2,7 +2,7 @@
  * This function takes an array and divides it into smaller arrays,
  * or "chunks", each containing a specified number of elements.
  * @param array The array to be split into chunks.
- * @param size The size of each chunk. The default size is 10.
+ * @param size The size of each chunk. The default size is 15.
  * @returns An array containing smaller subarrays (chunks), each with a length defined by the size.
  */
 export function chunkArray(array: any[], size = 15): any[] {


### PR DESCRIPTION
## Description

Fixes an incorrect JSDoc comment in the `chunkArray` utility function. The documentation stated that the default chunk size is 10, but the actual implementation uses 15 as the default value. This change updates the JSDoc to reflect the correct default parameter value.

**What kind of change does this PR introduce?** Documentation fix

**What is the current behavior?** 
JSDoc comment incorrectly states default size is 10

**What is the new behavior?** 
JSDoc comment correctly states default size is 15

**Does this PR introduce a breaking change?** 
No

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/semaphore-protocol/semaphore/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
