### PR TITLE
Add defensive checks in getDeployedContract for missing data

### DIFF
--- a/packages/utils/src/networks/index.ts
+++ b/packages/utils/src/networks/index.ts
@@ -54,9 +54,25 @@ export function getDeployedContract(supportedNetwork: SupportedNetwork) {
         throw new Error(`Semaphore has not been deployed on '${supportedNetwork}' yet`)
     }
 
-    const deployedContract = deployedContracts.find(({ network }) => network === supportedNetwork)
+    const networkDeployedContracts = deployedContracts.find(({ network }) => network === supportedNetwork)
 
-    return deployedContract!.contracts.find(({ name }) => name === "Semaphore") as {
+    if (!networkDeployedContracts) {
+        throw new Error(
+            `No deployed contracts found for network '${supportedNetwork}'. ` +
+                "Please ensure 'deployed-contracts.json' contains an entry for this network."
+        )
+    }
+
+    const semaphoreContract = networkDeployedContracts.contracts.find(({ name }) => name === "Semaphore")
+
+    if (!semaphoreContract) {
+        throw new Error(
+            `Contract 'Semaphore' not found in deployed contracts for network '${supportedNetwork}'. ` +
+                "Make sure deployments include 'Semaphore' for this network."
+        )
+    }
+
+    return semaphoreContract as {
         name: string
         address: string
         startBlock: number


### PR DESCRIPTION
Add explicit errors when no deployed contracts exist for a supported network.
Add explicit error when the 'Semaphore' contract is not found for that network.
These changes prevent opaque runtime crashes caused by non-null assertions and unsafe casts, and align error handling with patterns used in packages/contracts/scripts/utils.ts.