### PR TITLE
docs: add rel="noopener noreferrer" to external links in announcement bar

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -67,7 +67,7 @@ const config: Config = {
         announcementBar: {
             id: "semaphore-v4-beta",
             content:
-                '<b><a href="https://github.com/semaphore-protocol/semaphore/releases/tag/v4.0.0" target="_blank">Semaphore V4</a> is out 🎉 <a href="/getting-started">Try it out</a> and let us know if you have any feedback on <a href="https://semaphore.pse.dev/telegram" target="_blank">Telegram</a> or <a href="https://github.com/orgs/semaphore-protocol/discussions" target="_blank">Github</a>!</b>',
+                '<b><a href="https://github.com/semaphore-protocol/semaphore/releases/tag/v4.0.0" target="_blank" rel="noopener noreferrer">Semaphore V4</a> is out 🎉 <a href="/getting-started">Try it out</a> and let us know if you have any feedback on <a href="https://semaphore.pse.dev/telegram" target="_blank" rel="noopener noreferrer">Telegram</a> or <a href="https://github.com/orgs/semaphore-protocol/discussions" target="_blank" rel="noopener noreferrer">Github</a>!</b>',
             backgroundColor: "#dde6fc",
             textColor: "#000000"
         },


### PR DESCRIPTION
Prevent reverse tabnabbing by adding rel="noopener noreferrer" to external links opened with target="_blank".
