### PR TITLE
chore: remove unnecessary any from Jest projects configuration

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from "jest"
 
 const exclude = ["circuits", "contracts"]
 
-const projects: any = fs
+const projects = fs
     .readdirSync("./packages", { withFileTypes: true })
     .filter((directory) => directory.isDirectory())
     .filter((directory) => !exclude.includes(directory.name))


### PR DESCRIPTION
The projects array type is inferred from the map result and then validated against Config["projects"] when assigning config: Config = { projects, ... }. If the shape were incompatible, TypeScript would raise an error. The explicit : any annotation disabled that check, so removing it keeps the strict typing without changing runtime behavior.

## Checklist

-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
-   [ ] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
