### PR TITLE
feat(data): add semaphore event listeners

### DIFF
--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -333,4 +333,53 @@ export default class SemaphoreEthers {
         this._contract.removeAllListeners("MemberUpdated")
         this._contract.removeAllListeners("MemberRemoved")
     }
+
+    /**
+     * Listens to the ProofValidated event.
+     * @param callback Called with proof parameters.
+     */
+    onValidatedProof(
+        callback: (proof: {
+            groupId: string
+            merkleTreeDepth: number
+            merkleTreeRoot: string
+            nullifier: string
+            message: string
+            scope: string
+            points: string[]
+        }) => void
+    ): void {
+        this._contract.on(
+            "ProofValidated",
+            (groupId, merkleTreeDepth, merkleTreeRoot, nullifier, message, scope, points) => {
+                callback({
+                    groupId: groupId.toString(),
+                    merkleTreeDepth: Number(merkleTreeDepth),
+                    merkleTreeRoot: merkleTreeRoot.toString(),
+                    nullifier: nullifier.toString(),
+                    message: message.toString(),
+                    scope: scope.toString(),
+                    points: points.map((p: any) => p.toString())
+                })
+            }
+        )
+    }
+
+    offValidatedProof(): void {
+        this._contract.removeAllListeners("ProofValidated")
+    }
+
+    /**
+     * Listens to the GroupAdminUpdated event.
+     * @param callback Called with the old admin and new admin addresses.
+     */
+    onGroupAdmin(callback: (oldAdmin: string, newAdmin: string) => void): void {
+        this._contract.on("GroupAdminUpdated", (_groupId, oldAdmin, newAdmin) => {
+            callback(oldAdmin.toString(), newAdmin.toString())
+        })
+    }
+
+    offGroupAdmin(): void {
+        this._contract.removeAllListeners("GroupAdminUpdated")
+    }
 }

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -412,7 +412,7 @@ export default class SemaphoreEthers {
 
     /**
      * Listens to the GroupAdminUpdated event.
-     * @param callback callback Receives the groupId, old admin and new admin addresses and event metadata.
+     * @param callback Receives the groupId, old admin and new admin addresses and event metadata.
      */
     onGroupAdminUpdated(callback: (groupId: string, oldAdmin: string, newAdmin: string, event: any) => void): void {
         this._contract.on("GroupAdminUpdated", (groupId, oldAdmin, newAdmin, event) => {

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -375,7 +375,7 @@ export default class SemaphoreEthers {
 
     /**
      * Listens to the ProofValidated event.
-     * @param callback Called with proof parameters.
+     * @param callback Called with proof parameters and event metadata.
      */
     onProofValidated(
         callback: (proof: {
@@ -412,7 +412,7 @@ export default class SemaphoreEthers {
 
     /**
      * Listens to the GroupAdminUpdated event.
-     * @param callback Called with the old admin and new admin addresses.
+     * @param callback callback Receives the groupId, old admin and new admin addresses and event metadata.
      */
     onGroupAdminUpdated(callback: (groupId: string, oldAdmin: string, newAdmin: string, event: any) => void): void {
         this._contract.on("GroupAdminUpdated", (groupId, oldAdmin, newAdmin, event) => {

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -295,4 +295,42 @@ export default class SemaphoreEthers {
 
         return this._contract.hasMember(groupId, member)
     }
+
+    /**
+     * Listens to the GroupCreated event.
+     * @param callback Called with the groupId of the newly created group.
+     */
+    onGroup(callback: (groupId: string) => void): void {
+        this._contract.on("GroupCreated", (groupId: string) => {
+            callback(groupId.toString())
+        })
+    }
+
+    offGroup(): void {
+        this._contract.removeAllListeners("GroupCreated")
+    }
+
+    /**
+     * Listens to member-related events (MemberAdded, MemberRemoved, MemberUpdated).
+     * @param callback Called with member data depending on the event type.
+     */
+    onMember(callback: (eventType: string, identityCommitment: string, oldIdentityCommitment?: string) => void): void {
+        this._contract.on("MemberAdded", (_groupId, _index, identityCommitment) => {
+            callback("added", identityCommitment.toString())
+        })
+
+        this._contract.on("MemberUpdated", (_groupId, _index, oldIdentityCommitment, newIdentityCommitment) => {
+            callback("updated", newIdentityCommitment.toString(), oldIdentityCommitment.toString())
+        })
+
+        this._contract.on("MemberRemoved", (_groupId, _index, identityCommitment) => {
+            callback("removed", identityCommitment.toString())
+        })
+    }
+
+    offMember(): void {
+        this._contract.removeAllListeners("MemberAdded")
+        this._contract.removeAllListeners("MemberUpdated")
+        this._contract.removeAllListeners("MemberRemoved")
+    }
 }

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -414,9 +414,9 @@ export default class SemaphoreEthers {
      * Listens to the GroupAdminUpdated event.
      * @param callback Called with the old admin and new admin addresses.
      */
-    onGroupAdminUpdated(callback: (oldAdmin: string, newAdmin: string, event: any) => void): void {
-        this._contract.on("GroupAdminUpdated", (oldAdmin, newAdmin, event) => {
-            callback(oldAdmin.toString(), newAdmin.toString(), event)
+    onGroupAdminUpdated(callback: (groupId: string, oldAdmin: string, newAdmin: string, event: any) => void): void {
+        this._contract.on("GroupAdminUpdated", (groupId, oldAdmin, newAdmin, event) => {
+            callback(groupId.toString(), oldAdmin.toString(), newAdmin.toString(), event)
         })
     }
 

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -414,13 +414,13 @@ export default class SemaphoreEthers {
      * Listens to the GroupAdminUpdated event.
      * @param callback Called with the old admin and new admin addresses.
      */
-    onGroupAdmin(callback: (oldAdmin: string, newAdmin: string, event: any) => void): void {
+    onGroupAdminUpdated(callback: (oldAdmin: string, newAdmin: string, event: any) => void): void {
         this._contract.on("GroupAdminUpdated", (oldAdmin, newAdmin, event) => {
             callback(oldAdmin.toString(), newAdmin.toString(), event)
         })
     }
 
-    offGroupAdmin(): void {
+    offGroupAdminUpdated(): void {
         this._contract.removeAllListeners("GroupAdminUpdated")
     }
 }

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -306,6 +306,10 @@ export default class SemaphoreEthers {
         })
     }
 
+    /**
+     * Removes all listeners for the GroupCreated event.
+     * Stop receiving group creation notifications.
+     */
     offGropupCreated(): void {
         this._contract.removeAllListeners("GroupCreated")
     }
@@ -322,6 +326,10 @@ export default class SemaphoreEthers {
         })
     }
 
+    /**
+     * Removes all listeners for the MemberAdded event.
+     * Stop tracking when new members are added.
+     */
     offMemberAdded(): void {
         this._contract.removeAllListeners("MemberAdded")
     }
@@ -353,6 +361,10 @@ export default class SemaphoreEthers {
         )
     }
 
+    /**
+     * Removes all listeners for the MemberUpdated event.
+     * Stop receiving updates when members change their commitment.
+     */
     offMemberUpdated(): void {
         this._contract.removeAllListeners("MemberUpdated")
     }
@@ -369,6 +381,10 @@ export default class SemaphoreEthers {
         })
     }
 
+    /**
+     * Removes all listeners for the MemberRemoved event.
+     * Stop listening for member removals.
+     */
     offMemberRemoved(): void {
         this._contract.removeAllListeners("MemberRemoved")
     }
@@ -406,6 +422,10 @@ export default class SemaphoreEthers {
         )
     }
 
+    /**
+     * Removes all listeners for the ProofValidated event.
+     * Stop receiving proof validation notifications.
+     */
     offProofValidated(): void {
         this._contract.removeAllListeners("ProofValidated")
     }
@@ -420,6 +440,10 @@ export default class SemaphoreEthers {
         })
     }
 
+    /**
+     * Removes all listeners for the GroupAdminUpdated event.
+     * Stop tracking when a group's admin is updated.
+     */
     offGroupAdminUpdated(): void {
         this._contract.removeAllListeners("GroupAdminUpdated")
     }

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -300,37 +300,57 @@ export default class SemaphoreEthers {
      * Listens to the GroupCreated event.
      * @param callback Called with the groupId of the newly created group.
      */
-    onGroup(callback: (groupId: string) => void): void {
-        this._contract.on("GroupCreated", (groupId: string) => {
-            callback(groupId.toString())
+    onGroupCreated(callback: (groupId: string, event: any) => void): void {
+        this._contract.on("GroupCreated", (groupId, event) => {
+            callback(groupId.toString(), event)
         })
     }
 
-    offGroup(): void {
+    offGropupCreated(): void {
         this._contract.removeAllListeners("GroupCreated")
     }
 
     /**
-     * Listens to member-related events (MemberAdded, MemberRemoved, MemberUpdated).
-     * @param callback Called with member data depending on the event type.
+     * Listens to MemberAdded events.
+     * @param callback Receives the groupId, identityCommitment and event metadata.
      */
-    onMember(callback: (eventType: string, identityCommitment: string, oldIdentityCommitment?: string) => void): void {
-        this._contract.on("MemberAdded", (_groupId, _index, identityCommitment) => {
-            callback("added", identityCommitment.toString())
-        })
-
-        this._contract.on("MemberUpdated", (_groupId, _index, oldIdentityCommitment, newIdentityCommitment) => {
-            callback("updated", newIdentityCommitment.toString(), oldIdentityCommitment.toString())
-        })
-
-        this._contract.on("MemberRemoved", (_groupId, _index, identityCommitment) => {
-            callback("removed", identityCommitment.toString())
+    onMemberAdded(callback: (groupId: string, identityCommitment: string, event: any) => void): void {
+        this._contract.on("MemberAdded", (groupId, _index, identityCommitment, event) => {
+            callback(groupId.toString(), identityCommitment.toString(), event)
         })
     }
 
-    offMember(): void {
+    offMemberAdded(): void {
         this._contract.removeAllListeners("MemberAdded")
+    }
+
+    /**
+     * Listens to MemberUpdated events.
+     * @param callback Receives the groupId, old identityCommitment, new identityCommitment, and event metadata.
+     */
+    onMemberUpdated(
+        callback: (groupId: string, oldIdentityCommitment: string, newIdentityCommitment: string, event: any) => void
+    ): void {
+        this._contract.on("MemberUpdated", (groupId, _index, oldIdentityCommitment, newIdentityCommitment, event) => {
+            callback(groupId.toString(), oldIdentityCommitment.toString(), newIdentityCommitment.toString(), event)
+        })
+    }
+
+    offMemberUpdated(): void {
         this._contract.removeAllListeners("MemberUpdated")
+    }
+
+    /**
+     * Listens to MemberRemoved events.
+     * @param callback Receives the groupId, identityCommitment and event metadata.
+     */
+    onMemberRemoved(callback: (groupId: string, identityCommitment: string, event: any) => void): void {
+        this._contract.on("MemberRemoved", (groupId, _index, identityCommitment, event) => {
+            callback(groupId.toString(), identityCommitment.toString(), event)
+        })
+    }
+
+    offMemberRemoved(): void {
         this._contract.removeAllListeners("MemberRemoved")
     }
 
@@ -347,11 +367,12 @@ export default class SemaphoreEthers {
             message: string
             scope: string
             points: string[]
+            event: any
         }) => void
     ): void {
         this._contract.on(
             "ProofValidated",
-            (groupId, merkleTreeDepth, merkleTreeRoot, nullifier, message, scope, points) => {
+            (groupId, merkleTreeDepth, merkleTreeRoot, nullifier, message, scope, points, event) => {
                 callback({
                     groupId: groupId.toString(),
                     merkleTreeDepth: Number(merkleTreeDepth),
@@ -359,7 +380,8 @@ export default class SemaphoreEthers {
                     nullifier: nullifier.toString(),
                     message: message.toString(),
                     scope: scope.toString(),
-                    points: points.map((p: any) => p.toString())
+                    points: points.map((p: any) => p.toString()),
+                    event
                 })
             }
         )
@@ -373,9 +395,9 @@ export default class SemaphoreEthers {
      * Listens to the GroupAdminUpdated event.
      * @param callback Called with the old admin and new admin addresses.
      */
-    onGroupAdmin(callback: (oldAdmin: string, newAdmin: string) => void): void {
-        this._contract.on("GroupAdminUpdated", (_groupId, oldAdmin, newAdmin) => {
-            callback(oldAdmin.toString(), newAdmin.toString())
+    onGroupAdmin(callback: (oldAdmin: string, newAdmin: string, event: any) => void): void {
+        this._contract.on("GroupAdminUpdated", (oldAdmin, newAdmin, event) => {
+            callback(oldAdmin.toString(), newAdmin.toString(), event)
         })
     }
 

--- a/packages/data/src/ethers.ts
+++ b/packages/data/src/ethers.ts
@@ -314,9 +314,11 @@ export default class SemaphoreEthers {
      * Listens to MemberAdded events.
      * @param callback Receives the groupId, identityCommitment and event metadata.
      */
-    onMemberAdded(callback: (groupId: string, identityCommitment: string, event: any) => void): void {
-        this._contract.on("MemberAdded", (groupId, _index, identityCommitment, event) => {
-            callback(groupId.toString(), identityCommitment.toString(), event)
+    onMemberAdded(
+        callback: (groupId: string, identityCommitment: string, merkleTreeRoot: string, event: any) => void
+    ): void {
+        this._contract.on("MemberAdded", (groupId, _index, identityCommitment, merkleTreeRoot, event) => {
+            callback(groupId.toString(), identityCommitment.toString(), merkleTreeRoot.toString(), event)
         })
     }
 
@@ -329,11 +331,26 @@ export default class SemaphoreEthers {
      * @param callback Receives the groupId, old identityCommitment, new identityCommitment, and event metadata.
      */
     onMemberUpdated(
-        callback: (groupId: string, oldIdentityCommitment: string, newIdentityCommitment: string, event: any) => void
+        callback: (
+            groupId: string,
+            oldIdentityCommitment: string,
+            newIdentityCommitment: string,
+            merkleTreeRoot: string,
+            event: any
+        ) => void
     ): void {
-        this._contract.on("MemberUpdated", (groupId, _index, oldIdentityCommitment, newIdentityCommitment, event) => {
-            callback(groupId.toString(), oldIdentityCommitment.toString(), newIdentityCommitment.toString(), event)
-        })
+        this._contract.on(
+            "MemberUpdated",
+            (groupId, _index, oldIdentityCommitment, newIdentityCommitment, merkleTreeRoot, event) => {
+                callback(
+                    groupId.toString(),
+                    oldIdentityCommitment.toString(),
+                    newIdentityCommitment.toString(),
+                    merkleTreeRoot.toString(),
+                    event
+                )
+            }
+        )
     }
 
     offMemberUpdated(): void {
@@ -344,9 +361,11 @@ export default class SemaphoreEthers {
      * Listens to MemberRemoved events.
      * @param callback Receives the groupId, identityCommitment and event metadata.
      */
-    onMemberRemoved(callback: (groupId: string, identityCommitment: string, event: any) => void): void {
-        this._contract.on("MemberRemoved", (groupId, _index, identityCommitment, event) => {
-            callback(groupId.toString(), identityCommitment.toString(), event)
+    onMemberRemoved(
+        callback: (groupId: string, identityCommitment: string, merkleTreeRoot: string, event: any) => void
+    ): void {
+        this._contract.on("MemberRemoved", (groupId, _index, identityCommitment, merkleTreeRoot, event) => {
+            callback(groupId.toString(), identityCommitment.toString(), merkleTreeRoot.toString(), event)
         })
     }
 
@@ -358,7 +377,7 @@ export default class SemaphoreEthers {
      * Listens to the ProofValidated event.
      * @param callback Called with proof parameters.
      */
-    onValidatedProof(
+    onProofValidated(
         callback: (proof: {
             groupId: string
             merkleTreeDepth: number
@@ -387,7 +406,7 @@ export default class SemaphoreEthers {
         )
     }
 
-    offValidatedProof(): void {
+    offProofValidated(): void {
         this._contract.removeAllListeners("ProofValidated")
     }
 

--- a/packages/data/tests/ethers.test.ts
+++ b/packages/data/tests/ethers.test.ts
@@ -306,5 +306,51 @@ describe("SemaphoreEthers", () => {
             expect(cb).toHaveBeenNthCalledWith(2, "updated", "222", "111")
             expect(cb).toHaveBeenNthCalledWith(3, "removed", "333")
         })
+
+        it("onValidatedProof should call the callback with proof data", () => {
+            const semaphore = new SemaphoreEthers("sepolia", { address: "0x0000" })
+            const cb = jest.fn()
+
+            semaphore.onValidatedProof(cb)
+
+            const handler = mockOn.mock.calls.find(([e]) => e === "ProofValidated")![1]
+            handler("g1", 3, "root", "null", "msg", "scope", ["1", "2"])
+
+            expect(cb).toHaveBeenCalledWith({
+                groupId: "g1",
+                merkleTreeDepth: 3,
+                merkleTreeRoot: "root",
+                nullifier: "null",
+                message: "msg",
+                scope: "scope",
+                points: ["1", "2"]
+            })
+        })
+        it("onGroupAdmin should call the callback with old and new admin", () => {
+            const semaphore = new SemaphoreEthers("sepolia", { address: "0x0000" })
+            const cb = jest.fn()
+
+            semaphore.onGroupAdmin(cb)
+            const handler = mockOn.mock.calls.find(([e]) => e === "GroupAdminUpdated")![1]
+            handler("g1", "0xOLD", "0xNEW")
+
+            expect(cb).toHaveBeenCalledWith("0xOLD", "0xNEW")
+        })
+
+        it("off functions should remove all listeners", () => {
+            const semaphore = new SemaphoreEthers("sepolia", { address: "0x0000" })
+
+            semaphore.offGroup()
+            semaphore.offMember()
+            semaphore.offValidatedProof()
+            semaphore.offGroupAdmin()
+
+            expect(mockRemove).toHaveBeenCalledWith("GroupCreated")
+            expect(mockRemove).toHaveBeenCalledWith("MemberAdded")
+            expect(mockRemove).toHaveBeenCalledWith("MemberUpdated")
+            expect(mockRemove).toHaveBeenCalledWith("MemberRemoved")
+            expect(mockRemove).toHaveBeenCalledWith("ProofValidated")
+            expect(mockRemove).toHaveBeenCalledWith("GroupAdminUpdated")
+        })
     })
 })

--- a/packages/data/tests/ethers.test.ts
+++ b/packages/data/tests/ethers.test.ts
@@ -374,11 +374,11 @@ describe("SemaphoreEthers", () => {
             expect(mockRemove).toHaveBeenCalledWith("ProofValidated")
         })
 
-        it("onGroupAdmin should call callback with groupId, oldAdmin, newAdmin and event", () => {
+        it("onGroupAdminUpdated should call callback with groupId, oldAdmin, newAdmin and event", () => {
             const semaphore = new SemaphoreEthers("sepolia", { address: "0x0000" })
             const cb = jest.fn()
 
-            semaphore.onGroupAdmin(cb)
+            semaphore.onGroupAdminUpdated(cb)
             const handler = mockOn.mock.calls.find(([e]) => e === "GroupAdminUpdated")![1]
             const fakeEvent = { txHash: "0xbeef" }
 
@@ -387,9 +387,9 @@ describe("SemaphoreEthers", () => {
             expect(cb).toHaveBeenCalledWith("0xOLD", "0xNEW", fakeEvent)
         })
 
-        it("offGroupAdmin should remove all GroupAdminUpdated listeners", () => {
+        it("offGroupAdminUpdated should remove all GroupAdminUpdated listeners", () => {
             const semaphore = new SemaphoreEthers("sepolia", { address: "0x0000" })
-            semaphore.offGroupAdmin()
+            semaphore.offGroupAdminUpdated()
             expect(mockRemove).toHaveBeenCalledWith("GroupAdminUpdated")
         })
     })

--- a/packages/data/tests/ethers.test.ts
+++ b/packages/data/tests/ethers.test.ts
@@ -281,7 +281,6 @@ describe("SemaphoreEthers", () => {
 
             semaphore.onGroupCreated(cb)
 
-            // Simulamos la emisión del evento
             const handler = mockOn.mock.calls.find(([e]) => e === "GroupCreated")![1]
             const fakeEvent = { blockNumber: 123 }
             handler("42", fakeEvent)

--- a/packages/data/tests/ethers.test.ts
+++ b/packages/data/tests/ethers.test.ts
@@ -303,9 +303,9 @@ describe("SemaphoreEthers", () => {
             const handler = mockOn.mock.calls.find(([e]) => e === "MemberAdded")![1]
             const fakeEvent = { txHash: "0xabc" }
 
-            handler("group1", 0, "identity123", fakeEvent)
+            handler("group1", 0, "identity123", "root111", fakeEvent)
 
-            expect(cb).toHaveBeenCalledWith("group1", "identity123", fakeEvent)
+            expect(cb).toHaveBeenCalledWith("group1", "identity123", "root111", fakeEvent)
         })
 
         it("onMemberUpdated should call callback with groupId, old and new identity commitments", () => {
@@ -316,9 +316,9 @@ describe("SemaphoreEthers", () => {
             const handler = mockOn.mock.calls.find(([e]) => e === "MemberUpdated")![1]
             const fakeEvent = { blockNumber: 200 }
 
-            handler("groupX", 1, "old123", "new456", fakeEvent)
+            handler("groupX", 1, "old123", "new456", "root111", fakeEvent)
 
-            expect(cb).toHaveBeenCalledWith("groupX", "old123", "new456", fakeEvent)
+            expect(cb).toHaveBeenCalledWith("groupX", "old123", "new456", "root111", fakeEvent)
         })
 
         it("onMemberRemoved should call callback with groupId, identityCommitment and event", () => {
@@ -329,9 +329,9 @@ describe("SemaphoreEthers", () => {
             const handler = mockOn.mock.calls.find(([e]) => e === "MemberRemoved")![1]
             const fakeEvent = { txHash: "0xdeadbeef" }
 
-            handler("groupZ", 2, "identity999", fakeEvent)
+            handler("groupZ", 2, "identity999", "root111", fakeEvent)
 
-            expect(cb).toHaveBeenCalledWith("groupZ", "identity999", fakeEvent)
+            expect(cb).toHaveBeenCalledWith("groupZ", "identity999", "root111", fakeEvent)
         })
 
         it("offMemberAdded/Updated/Removed should remove all corresponding listeners", () => {
@@ -346,11 +346,11 @@ describe("SemaphoreEthers", () => {
             expect(mockRemove).toHaveBeenCalledWith("MemberRemoved")
         })
 
-        it("onValidatedProof should call callback with proof object", () => {
+        it("onProofValidated should call callback with proof object", () => {
             const semaphore = new SemaphoreEthers("sepolia", { address: "0x0000" })
             const cb = jest.fn()
 
-            semaphore.onValidatedProof(cb)
+            semaphore.onProofValidated(cb)
             const handler = mockOn.mock.calls.find(([e]) => e === "ProofValidated")![1]
 
             const fakeEvent = { blockNumber: 400 }
@@ -368,9 +368,9 @@ describe("SemaphoreEthers", () => {
             })
         })
 
-        it("offValidatedProof should remove all ProofValidated listeners", () => {
+        it("offProofValidated should remove all ProofValidated listeners", () => {
             const semaphore = new SemaphoreEthers("sepolia", { address: "0x0000" })
-            semaphore.offValidatedProof()
+            semaphore.offProofValidated()
             expect(mockRemove).toHaveBeenCalledWith("ProofValidated")
         })
 

--- a/packages/data/tests/ethers.test.ts
+++ b/packages/data/tests/ethers.test.ts
@@ -382,9 +382,9 @@ describe("SemaphoreEthers", () => {
             const handler = mockOn.mock.calls.find(([e]) => e === "GroupAdminUpdated")![1]
             const fakeEvent = { txHash: "0xbeef" }
 
-            handler("0xOLD", "0xNEW", fakeEvent)
+            handler("group1", "0xOLD", "0xNEW", fakeEvent)
 
-            expect(cb).toHaveBeenCalledWith("0xOLD", "0xNEW", fakeEvent)
+            expect(cb).toHaveBeenCalledWith("group1", "0xOLD", "0xNEW", fakeEvent)
         })
 
         it("offGroupAdminUpdated should remove all GroupAdminUpdated listeners", () => {

--- a/packages/data/tests/ethers.test.ts
+++ b/packages/data/tests/ethers.test.ts
@@ -292,7 +292,7 @@ describe("SemaphoreEthers", () => {
 
             semaphore.onMember(cb)
 
-            // simulamos las tres variantes
+            // Simulate three variants
             const added = mockOn.mock.calls.find(([e]) => e === "MemberAdded")![1]
             added("g1", 0, "111")
 


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->
The following listeners have been added to the SemaphoreEthers class:

- onGroup (GroupCreated event): Return the ID of the newly created group.
- onMember (MemberRemoved, MemberUpdated, MemberAdded events): Return the identity confirmation of the added, updated, or deleted members. For updates , the previous identity confirmation is returned.
- onValidatedProof (ProofValidated event): Return the parameters of a validated proof.
- onGroupAdmin (GroupAdminUpdated event): Return the addresses of the old and new admins.
## Related Issue(s)
#326 
<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->


## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

