### PR TITLE
docs(website): added Bring ID data to projects list

### DIFF
--- a/apps/website/src/data/projects.json
+++ b/apps/website/src/data/projects.json
@@ -596,5 +596,16 @@
         "links": {
             "website": "https://poll.cc"
         }
+    },
+    {
+        "name": "BringID",
+        "tagline": "Privacy-preserving proof of humanity using verifiable Internet credentials",
+        "categories": ["Identity", "Authenticity", "Trust"],
+        "pse": false,
+        "icon": "",
+        "links": {
+            "website": "https://www.bringid.org",
+            "github": "https://github.com/BringID/whitepaper"
+        }
     }
 ]


### PR DESCRIPTION
## Description

updated website list of projects, to show BringID project in the grid under the "Built with Semaphore" section

## Related Issue(s)

https://github.com/semaphore-protocol/semaphore/issues/1001

## Checklist

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes