### PR TITLE
fix(website): prevent NaN index access in circularSlice utility

### DIFF
--- a/apps/website/src/utils/circularSlice.ts
+++ b/apps/website/src/utils/circularSlice.ts
@@ -10,6 +10,10 @@
  * @returns A new array containing the extracted elements.
  */
 export function circularSlice(list: any[], index: number, numberOfItems: number): any[] {
+    // Return empty array for empty input or non-positive count to avoid NaN index access
+    if (list.length === 0 || numberOfItems <= 0) {
+        return []
+    }
     const result = []
 
     for (let i = 0; i < numberOfItems; i += 1) {


### PR DESCRIPTION

## Description

**What kind of change does this PR introduce?** Bug fix

**What is the current behavior?** The `circularSlice` function returns an array of `undefined` values when called with an empty input array, due to modulo operation with zero (`(index + i) % 0` results in `NaN`).

**What is the new behavior?** The function now returns an empty array `[]` for empty input arrays or non-positive item counts, preventing `NaN` index access and subsequent rendering issues.

**Does this PR introduce a breaking change?** No

## Related Issue(s)

N/A - Internal code quality improvement

## Other information

This fix prevents potential runtime errors when the `circularSlice` utility is used with empty arrays, ensuring consistent behavior and preventing downstream issues in components that rely on this utility.

