### PR TITLE
fix(cli): add timeout to axios request in version check

### DIFF
--- a/packages/cli/src/checkLatestVersion.ts
+++ b/packages/cli/src/checkLatestVersion.ts
@@ -16,7 +16,7 @@ export default async function checkLatestVersion(currentVersion: string) {
     let latestVersion: string
 
     try {
-        const { data } = await axios.get(cliRegistryURL)
+        const { data } = await axios.get(cliRegistryURL, { timeout: 5000 })
 
         latestVersion = data.latest
     } catch {


### PR DESCRIPTION
Adds 5-second timeout to axios.get() call to prevent CLI from hanging when checking for latest version. 

Without timeout, the request could block indefinitely on slow or unresponsive networks.