### PR TITLE
chore: remove dead code from clean-packages script

### DIFF
--- a/scripts/clean-packages.ts
+++ b/scripts/clean-packages.ts
@@ -13,9 +13,6 @@ async function main() {
     folders.forEach((app) =>
         gitIgnored.forEach((f) => rmSync(`${folderName}/${app}/${f}`, { recursive: true, force: true }))
     )
-
-    rmSync(`${folderName}/circuit/main`, { recursive: true, force: true })
-    rmSync(`${folderName}/circuit/test`, { recursive: true, force: true })
 }
 
 main()


### PR DESCRIPTION
Removed two lines that tried to delete `packages/circuit/main` and `packages/circuit/test`. 

These never worked due to a typo (folder is `circuits` not `circuit`), and even with the fix they're useless - circomkit 0.3.3 only generates a `build` folder, which is already handled by the main cleanup loop. The `main`/`test` directories don't exist and won't be created.

