### PR TITLE
docs(identity): correct Identity constructor parameter types and examples

### DIFF
--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -72,7 +72,7 @@ yarn add @semaphore-protocol/identity
 
 For more information on the functions provided by `@semaphore-protocol/identity`, please refer to the [TypeDoc documentation](https://js.semaphore.pse.dev/modules/_semaphore_protocol_identity).
 
-\# **new Identity**(privateKey?: _BigNumberish_): _Identity_
+\# **new Identity**(privateKey?: _string | Buffer | Uint8Array_): _Identity_
 
 ```typescript
 import { Identity } from "@semaphore-protocol/identity"
@@ -82,6 +82,8 @@ const { privateKey, publicKey, commitment } = new Identity()
 
 // Alternatively, you can pass your private key.
 const identity = new Identity("your-private-key")
+const identityFromBuffer = new Identity(Buffer.from("your-private-key"))
+const identityFromUint8 = new Identity(new Uint8Array([1, 2, 3]))
 ```
 
 \# **identity.export**(): _string_

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -40,8 +40,11 @@ export class Identity {
      * @example
      * // Generates an identity with a random private key.
      * const { privateKey, publicKey, commitment } = new Identity()
+     * @example
+     * // Generates an identity from a Buffer private key.
+     * const { privateKey, publicKey, commitment } = new Identity(Buffer.from("private-key"))
      *
-     * @param privateKey The private key used to derive the public key (hexadecimal or string).
+     * @param privateKey The private key used to derive the public key (string, Buffer, or Uint8Array).
      */
     constructor(privateKey?: string | Buffer | Uint8Array) {
         const eddsa = new EdDSAPoseidon(privateKey)

--- a/packages/identity/tests/index.test.ts
+++ b/packages/identity/tests/index.test.ts
@@ -130,7 +130,7 @@ describe("Identity", () => {
             expect(Identity.verifySignature("message", signature, identity.publicKey)).toBeTruthy()
         })
 
-        it("Should verify a signature with hexadecimal private key", () => {
+        it("Should verify a signature with a Buffer private key", () => {
             const identity = new Identity(privateKeyBuffer)
 
             const signature = identity.signMessage("message")


### PR DESCRIPTION
The Identity constructor accepts string, Buffer, and Uint8Array as confirmed by implementation and unit tests, but the JSDoc referenced “hexadecimal or string” and the README showed BigNumberish. I aligned both docs to the actual API and added Buffer/Uint8Array examples; also renamed a misleading test title to reflect the Buffer case.