### PR TITLE
Remove redundant group.save() in addValidatedProof

### DIFF
--- a/apps/subgraph/src/semaphore.ts
+++ b/apps/subgraph/src/semaphore.ts
@@ -222,10 +222,7 @@ export function addValidatedProof(event: ProofValidated): void {
         validatedProof.nullifier = event.params.nullifier
         validatedProof.points = event.params.points
         validatedProof.timestamp = event.block.timestamp
-
         validatedProof.save()
-
-        group.save()
 
         log.info("Validated proof with message '{}' in the onchain group '{}' has been added", [
             event.params.message.toHexString(),


### PR DESCRIPTION
 The group.save() call in addValidatedProof saved the Group entity without any modifications. Since Group.validatedProofs is defined via @derivedFrom(field: "group"), The Graph resolves the relation from the child (ValidatedProof.group) and does not require saving the parent. Removing this avoids an unnecessary store write during indexing.