### PR TITLE
fix: correct ProofValidated event scope parameter in test assertions

### DIFF
--- a/packages/contracts/test/Semaphore.ts
+++ b/packages/contracts/test/Semaphore.ts
@@ -514,7 +514,7 @@ describe("Semaphore", () => {
                     proof.merkleTreeRoot,
                     proof.nullifier,
                     proof.message,
-                    proof.merkleTreeRoot,
+                    proof.scope,
                     proof.points
                 )
         })
@@ -540,7 +540,7 @@ describe("Semaphore", () => {
                     proof.merkleTreeRoot,
                     proof.nullifier,
                     proof.message,
-                    proof.merkleTreeRoot,
+                    proof.scope,
                     proof.points
                 )
         })
@@ -558,7 +558,7 @@ describe("Semaphore", () => {
                     proof.merkleTreeRoot,
                     proof.nullifier,
                     proof.message,
-                    proof.merkleTreeRoot,
+                    proof.scope,
                     proof.points
                 )
         })


### PR DESCRIPTION
Fixed copy-paste error in ProofValidated event assertions where proof.merkleTreeRoot was incorrectly used twice. The event's 6th parameter should be proof.scope, so updated 3 test cases (lines 517, 543, 561) to pass the correct value.