### PR TITLE
docs(readme): correct artifact copy path and flattened destination filename

### DIFF
--- a/packages/cli-template-monorepo-ethers/README.md
+++ b/packages/cli-template-monorepo-ethers/README.md
@@ -30,7 +30,7 @@ yarn deploy --semaphore <semaphore-address> --network sepolia
 
 2. Update your `apps/web-app/.env.production` file with your new contract address and the group id.
 
-3. Copy your contract artifacts from `apps/contracts/artifacts/contracts/` folder to `apps/web-app/contract-artifacts` folder manually.
+3. Copy `apps/contracts/artifacts/contracts/Feedback.sol/Feedback.json` to `apps/web-app/contract-artifacts/Feedback.json` manually (note the flattened filename).
 
 > [!NOTE]
 > Check the Semaphore contract addresses [here](https://docs.semaphore.pse.dev/deployed-contracts).


### PR DESCRIPTION
This change updates the deployment instructions to copy the exact ABI file produced by Hardhat from apps/contracts/artifacts/contracts/Feedback.sol/Feedback.json to a flattened path at apps/web-app/contract-artifacts/Feedback.json, which matches how the web app imports the artifact (e.g., src/app/api/feedback/route.ts and src/app/group/page.tsx). The previous guidance suggested copying the whole artifacts/contracts folder, which would result in a nested Feedback.sol/Feedback.json path that breaks imports. Aligning the README with the actual import shape avoids runtime module resolution errors and ensures a smooth setup.