### PR TITLE
fix: correct root getter JSDoc return type

### DIFF
--- a/packages/group/src/index.ts
+++ b/packages/group/src/index.ts
@@ -34,7 +34,7 @@ export class Group {
 
     /**
      * Returns the root hash of the tree.
-     * @returns The root hash as a string.
+     * @returns The root hash as a bigint.
      */
     public get root(): bigint {
         return this.leanIMT.root ? this.leanIMT.root : 0n


### PR DESCRIPTION
The Group.root getter has always returned a bigint, and all usages and tests rely on this type. The previous JSDoc incorrectly documented the return value as a string, which could mislead users and documentation tooling. This change updates the JSDoc to state that the getter returns a bigint, keeping the public API and runtime behavior unchanged.