### PR TITLE
fix: remove trailing whitespace from Optimism RPC URL

### DIFF
--- a/packages/utils/src/networks/supported-networks.ts
+++ b/packages/utils/src/networks/supported-networks.ts
@@ -31,7 +31,7 @@ export default {
     },
     optimism: {
         name: "Optimism",
-        url: "https://mainnet.optimism.io ",
+        url: "https://mainnet.optimism.io",
         chainId: 10,
         explorer: "https://optimistic.etherscan.io"
     },


### PR DESCRIPTION
The Optimism RPC endpoint in supported-networks.ts contained a trailing space character, which can break strict JSON-RPC clients and string-based checks that consume this URL. This change normalizes the value to the canonical https://mainnet.optimism.io so downstream tools like Hardhat and any user code using supportedNetworks.optimism.url receive a clean, valid endpoint.